### PR TITLE
Board Utility

### DIFF
--- a/src/AdafruitIO.cpp
+++ b/src/AdafruitIO.cpp
@@ -209,6 +209,12 @@ const char* AdafruitIO::boardType()
   return AdafruitIO_Board::type();
 }
 
+char* AdafruitIO::version()
+{
+  sprintf(_version, "%d.%d.%d", ADAFRUITIO_VERSION_MAJOR, ADAFRUITIO_VERSION_MINOR, ADAFRUITIO_VERSION_PATCH);
+  return _version;
+}
+
 aio_status_t AdafruitIO::mqttStatus()
 {
   // if the connection failed,

--- a/src/AdafruitIO.cpp
+++ b/src/AdafruitIO.cpp
@@ -199,9 +199,14 @@ aio_status_t AdafruitIO::status()
   return _status;
 }
 
-char* AdafruitIO::id()
+char* AdafruitIO::boardID()
 {
   return AdafruitIO_Board::id();
+}
+
+const char* AdafruitIO::boardType()
+{
+  return AdafruitIO_Board::type();
 }
 
 aio_status_t AdafruitIO::mqttStatus()

--- a/src/AdafruitIO.cpp
+++ b/src/AdafruitIO.cpp
@@ -199,6 +199,11 @@ aio_status_t AdafruitIO::status()
   return _status;
 }
 
+char* AdafruitIO::id()
+{
+  return AdafruitIO_Board::id();
+}
+
 aio_status_t AdafruitIO::mqttStatus()
 {
   // if the connection failed,

--- a/src/AdafruitIO.h
+++ b/src/AdafruitIO.h
@@ -19,6 +19,7 @@
 #include "AdafruitIO_Dashboard.h"
 #include "AdafruitIO_Data.h"
 #include "ArduinoHttpClient.h"
+#include "util/AdafruitIO_Board.h"
 
 #ifndef ADAFRUIT_MQTT_VERSION_MAJOR
   #error "This sketch requires Adafruit MQTT Library v0.16.0 or higher. Please install or upgrade using the Library Manager."
@@ -52,6 +53,7 @@ class AdafruitIO {
 
     aio_status_t status();
     virtual aio_status_t networkStatus() = 0;
+    char* id();
     aio_status_t mqttStatus();
 
   protected:

--- a/src/AdafruitIO.h
+++ b/src/AdafruitIO.h
@@ -57,6 +57,7 @@ class AdafruitIO {
 
     char* boardID();
     const char* boardType();
+    virtual const char* connectionType() = 0;
 
   protected:
     virtual void _connect() = 0;

--- a/src/AdafruitIO.h
+++ b/src/AdafruitIO.h
@@ -53,8 +53,10 @@ class AdafruitIO {
 
     aio_status_t status();
     virtual aio_status_t networkStatus() = 0;
-    char* id();
     aio_status_t mqttStatus();
+
+    char* boardID();
+    const char* boardType();
 
   protected:
     virtual void _connect() = 0;

--- a/src/AdafruitIO.h
+++ b/src/AdafruitIO.h
@@ -57,6 +57,7 @@ class AdafruitIO {
 
     char* boardID();
     const char* boardType();
+    char* version();
     virtual const char* connectionType() = 0;
 
   protected:
@@ -66,6 +67,8 @@ class AdafruitIO {
 
     Adafruit_MQTT *_mqtt;
     HttpClient *_http;
+
+    char _version[10];
 
     const char *_host = "io.adafruit.com";
     uint16_t _mqtt_port = 8883;

--- a/src/AdafruitIO_Ethernet.h
+++ b/src/AdafruitIO_Ethernet.h
@@ -51,6 +51,11 @@ class AdafruitIO_Ethernet : public AdafruitIO {
       return _status;
     }
 
+    const char* connectionType()
+    {
+      return "ethernet_wing";
+    }
+
   protected:
     byte _mac[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED};
     uint16_t _port = 1883;

--- a/src/AdafruitIO_FONA.h
+++ b/src/AdafruitIO_FONA.h
@@ -68,6 +68,11 @@ class AdafruitIO_FONA : public AdafruitIO {
       return AIO_NET_CONNECTED;
     }
 
+    const char* connectionType()
+    {
+      return "fona";
+    }
+
   protected:
     uint16_t _mqtt_port = 1883;
 

--- a/src/util/AdafruitIO_Board.cpp
+++ b/src/util/AdafruitIO_Board.cpp
@@ -13,6 +13,25 @@
 
 char AdafruitIO_Board::_id[64] = "";
 
+#if defined(ARDUINO_SAMD_MKR1000)
+    const char AdafruitIO_Board::_type[] = "mkr1000";
+#elif defined(ARDUINO_SAMD_FEATHER_M0)
+    const char AdafruitIO_Board::_type[] = "feather_m0";
+#elif defined(ARDUINO_AVR_FEATHER32U4)
+    const char AdafruitIO_Board::_type[] = "feather_32u4";
+#elif defined(ARDUINO_STM32_FEATHER)
+    const char AdafruitIO_Board::_type[] = "feather_wiced";
+#elif defined(ESP8266)
+    const char AdafruitIO_Board::_type[] = "esp8266";
+#else
+    const char AdafruitIO_Board::_type[] = "unknown";
+#endif
+
+const char* AdafruitIO_Board::type()
+{
+  return AdafruitIO_Board::_type;
+}
+
 #if defined(ARDUINO_ARCH_SAMD)
 
   char* AdafruitIO_Board::id()

--- a/src/util/AdafruitIO_Board.cpp
+++ b/src/util/AdafruitIO_Board.cpp
@@ -1,0 +1,61 @@
+//
+// Adafruit invests time and resources providing this open source code.
+// Please support Adafruit and open source hardware by purchasing
+// products from Adafruit!
+//
+// Copyright (c) 2015-2016 Adafruit Industries
+// Authors: Todd Treece
+// Licensed under the MIT license.
+//
+// All text above must be included in any redistribution.
+//
+#include "AdafruitIO_Board.h"
+
+char AdafruitIO_Board::_id[64] = "";
+
+#if defined(ARDUINO_ARCH_SAMD)
+
+  char* AdafruitIO_Board::id()
+  {
+    volatile uint32_t val1, val2, val3, val4;
+    volatile uint32_t *ptr1 = (volatile uint32_t *)0x0080A00C;
+    val1 = *ptr1;
+    volatile uint32_t *ptr = (volatile uint32_t *)0x0080A040;
+    val2 = *ptr;
+    ptr++;
+    val3 = *ptr;
+    ptr++;
+    val4 = *ptr;
+
+    sprintf(AdafruitIO_Board::_id, "%8x%8x%8x%8x", val1, val2, val3, val4);
+
+    return AdafruitIO_Board::_id;
+  }
+
+#elif defined(ARDUINO_ARCH_AVR)
+
+  char* AdafruitIO_Board::id()
+  {
+    for(int i=0; i < 32; i++) {
+      sprintf(&AdafruitIO_Board::_id[i*2],"%02x", boot_signature_byte_get(i));
+    }
+    return AdafruitIO_Board::_id;
+  }
+
+#elif defined(ESP8266)
+
+  char* AdafruitIO_Board::id()
+  {
+    sprintf(AdafruitIO_Board::_id, "%06x", ESP.getChipId());
+    return AdafruitIO_Board::_id;
+  }
+
+#else
+
+  char* AdafruitIO_Board::id()
+  {
+    strcpy(AdafruitIO_Board::_id, "unknown");
+    return AdafruitIO_Board::_id;
+  }
+
+#endif

--- a/src/util/AdafruitIO_Board.cpp
+++ b/src/util/AdafruitIO_Board.cpp
@@ -69,6 +69,15 @@ const char* AdafruitIO_Board::type()
     return AdafruitIO_Board::_id;
   }
 
+#elif defined(ARDUINO_STM32_FEATHER)
+
+  char* AdafruitIO_Board::id()
+  {
+    uint32_t* p_unique_id = (uint32_t*) (0x1FFF7A10);
+    sprintf(AdafruitIO_Board::_id, "%08lX%08lX%08lX", p_unique_id[2], p_unique_id[1], p_unique_id[0]);
+    return AdafruitIO_Board::_id;
+  }
+
 #else
 
   char* AdafruitIO_Board::id()

--- a/src/util/AdafruitIO_Board.h
+++ b/src/util/AdafruitIO_Board.h
@@ -1,0 +1,30 @@
+//
+// Adafruit invests time and resources providing this open source code.
+// Please support Adafruit and open source hardware by purchasing
+// products from Adafruit!
+//
+// Copyright (c) 2015-2017 Adafruit Industries
+// Authors: Todd Treece
+// Licensed under the MIT license.
+//
+// All text above must be included in any redistribution.
+//
+#ifndef ADAFRUITIO_BOARD_H
+#define ADAFRUITIO_BOARD_H
+
+#include "Arduino.h"
+
+#if defined(ARDUINO_ARCH_AVR)
+  #include <avr/boot.h>
+#endif
+
+class AdafruitIO_Board {
+
+  public:
+
+    static char _id[64];
+    static char* id();
+
+};
+
+#endif // ADAFRUITIO_BOARD_H

--- a/src/util/AdafruitIO_Board.h
+++ b/src/util/AdafruitIO_Board.h
@@ -25,6 +25,10 @@ class AdafruitIO_Board {
     static char _id[64];
     static char* id();
 
+    static const char _type[];
+    static const char* type();
+
+
 };
 
 #endif // ADAFRUITIO_BOARD_H

--- a/src/wifi/AdafruitIO_ESP8266.cpp
+++ b/src/wifi/AdafruitIO_ESP8266.cpp
@@ -65,4 +65,9 @@ aio_status_t AdafruitIO_ESP8266::networkStatus()
 
 }
 
+const char* AdafruitIO_ESP8266::connectionType()
+{
+  return "wifi";
+}
+
 #endif // ESP8266

--- a/src/wifi/AdafruitIO_ESP8266.h
+++ b/src/wifi/AdafruitIO_ESP8266.h
@@ -29,6 +29,7 @@ class AdafruitIO_ESP8266 : public AdafruitIO {
     ~AdafruitIO_ESP8266();
 
     aio_status_t networkStatus();
+    const char* connectionType();
 
   protected:
     void _connect();

--- a/src/wifi/AdafruitIO_MKR1000.cpp
+++ b/src/wifi/AdafruitIO_MKR1000.cpp
@@ -67,4 +67,9 @@ aio_status_t AdafruitIO_MKR1000::networkStatus()
 
 }
 
+const char* AdafruitIO_MKR1000::connectionType()
+{
+  return "wifi";
+}
+
 #endif // ARDUINO_ARCH_SAMD

--- a/src/wifi/AdafruitIO_MKR1000.h
+++ b/src/wifi/AdafruitIO_MKR1000.h
@@ -30,6 +30,7 @@ class AdafruitIO_MKR1000 : public AdafruitIO {
     ~AdafruitIO_MKR1000();
 
     aio_status_t networkStatus();
+    const char* connectionType();
 
   protected:
     void _connect();

--- a/src/wifi/AdafruitIO_WICED.cpp
+++ b/src/wifi/AdafruitIO_WICED.cpp
@@ -58,4 +58,9 @@ aio_status_t AdafruitIO_WICED::networkStatus()
   return AIO_NET_DISCONNECTED;
 }
 
+const char* AdafruitIO_WICED::connectionType()
+{
+  return "wifi";
+}
+
 #endif // ARDUINO_STM32_FEATHER

--- a/src/wifi/AdafruitIO_WICED.h
+++ b/src/wifi/AdafruitIO_WICED.h
@@ -29,6 +29,7 @@ class AdafruitIO_WICED : public AdafruitIO {
     ~AdafruitIO_WICED();
 
     aio_status_t networkStatus();
+    const char* connectionType();
 
   protected:
     void _connect();

--- a/src/wifi/AdafruitIO_WINC1500.cpp
+++ b/src/wifi/AdafruitIO_WINC1500.cpp
@@ -76,4 +76,9 @@ aio_status_t AdafruitIO_WINC1500::networkStatus()
 
 }
 
+const char* AdafruitIO_WINC1500::connectionType()
+{
+  return "winc1500";
+}
+
 #endif // ARDUINO_ARCH_SAMD

--- a/src/wifi/AdafruitIO_WINC1500.h
+++ b/src/wifi/AdafruitIO_WINC1500.h
@@ -35,6 +35,7 @@ class AdafruitIO_WINC1500 : public AdafruitIO {
     ~AdafruitIO_WINC1500();
 
     aio_status_t networkStatus();
+    const char* connectionType();
 
   protected:
     void _connect();


### PR DESCRIPTION
## changes

* adds unique id helper function for all supported boards
* adds mcu type helper function
* adds io lib version helper function
* adds connection type (wifi, fona, ethernet, etc) helper function
* adds user agent helper function

## examples & testing

feather fona 32u4:

```
unique id: 1e5d955b875bffff00fffff7ffff583435363431150e1414170b12081308ffff
board type: feather_32u4
connection type: fona
version: 2.0.0
user agent: AdafruitIO-Arduino/2.0.0 (feather_32u4-fona)
```

feather esp8266:

```
unique id: 151f55
board type: esp8266
connection type: wifi
version: 2.0.0
user agent: AdafruitIO-Arduino/2.0.0 (esp8266-wifi)
```

feather m0 winc1500:

```
unique id: 73633edc514d464646202020ff0f0837
board type: feather_m0
connection type: winc1500
version: 2.0.0
user agent: AdafruitIO-Arduino/2.0.0 (feather_m0-winc1500)
```

mkr1000:

```
unique id: f438f189514d4d5447202020ff011228
board type: mkr1000
connection type: wifi
version: 2.0.0
user agent: AdafruitIO-Arduino/2.0.0 (mkr1000-wifi)
```

feather wiced:

```
ID: 353231313533470D0020002A
board type: feather_wiced
connection type: wifi
version: 2.0.0
user agent: AdafruitIO-Arduino/2.0.0 (feather_wiced-wifi)
```