### PR TITLE
ArduinoHttpClient v0.2.0 support

### DIFF
--- a/src/AdafruitIO_Dashboard.cpp
+++ b/src/AdafruitIO_Dashboard.cpp
@@ -27,7 +27,8 @@ bool AdafruitIO_Dashboard::exists()
   url += "/dashboards/";
   url += name;
 
-  _io->_http->startRequest(url.c_str(), HTTP_METHOD_GET);
+  _io->_http->beginRequest();
+  _io->_http->get(url.c_str());
   _io->_http->sendHeader("X-AIO-Key", _io->_key);
   _io->_http->endRequest();
 
@@ -46,12 +47,21 @@ bool AdafruitIO_Dashboard::create()
   String body = "name=";
   body += name;
 
-  _io->_http->startRequest(url.c_str(), HTTP_METHOD_POST);
-  _io->_http->sendHeader(HTTP_HEADER_CONTENT_TYPE, "application/x-www-form-urlencoded");
-  _io->_http->sendHeader(HTTP_HEADER_CONTENT_LENGTH, body.length());
+  _io->_http->beginRequest();
+  _io->_http->post(url.c_str());
+
+  _io->_http->sendHeader("Content-Type", "application/x-www-form-urlencoded");
+  _io->_http->sendHeader("Content-Length", body.length());
   _io->_http->sendHeader("X-AIO-Key", _io->_key);
+
+  // the following call to endRequest
+  // should be replaced by beginBody once the
+  // Arduino HTTP Client Library is updated
+  // _io->_http->beginBody();
   _io->_http->endRequest();
-  _io->_http->write((const byte*)body.c_str(), body.length());
+
+  _io->_http->print(body);
+  _io->_http->endRequest();
 
   int status = _io->_http->responseStatusCode();
   _io->_http->responseBody(); // needs to be read even if not used

--- a/src/AdafruitIO_Feed.cpp
+++ b/src/AdafruitIO_Feed.cpp
@@ -105,11 +105,14 @@ bool AdafruitIO_Feed::save(double value, double lat, double lon, double ele, int
 
 bool AdafruitIO_Feed::exists()
 {
-  _io->_http->startRequest(_feed_url, HTTP_METHOD_GET);
+  _io->_http->beginRequest();
+  _io->_http->get(_feed_url);
   _io->_http->sendHeader("X-AIO-Key", _io->_key);
   _io->_http->endRequest();
+
   int status = _io->_http->responseStatusCode();
   _io->_http->responseBody(); // needs to be read even if not used
+
   return status == 200;
 }
 
@@ -118,15 +121,25 @@ bool AdafruitIO_Feed::create()
   String body = "name=";
   body += name;
 
-  _io->_http->startRequest(_create_url, HTTP_METHOD_POST);
-  _io->_http->sendHeader(HTTP_HEADER_CONTENT_TYPE, "application/x-www-form-urlencoded");
-  _io->_http->sendHeader(HTTP_HEADER_CONTENT_LENGTH, body.length());
+  _io->_http->beginRequest();
+  _io->_http->post(_create_url);
+
+  _io->_http->sendHeader("Content-Type", "application/x-www-form-urlencoded");
+  _io->_http->sendHeader("Content-Length", body.length());
   _io->_http->sendHeader("X-AIO-Key", _io->_key);
+
+  // the following call to endRequest
+  // should be replaced by beginBody once the
+  // Arduino HTTP Client Library is updated
+  // _io->_http->beginBody();
   _io->_http->endRequest();
-  _io->_http->write((const byte*)body.c_str(), body.length());
+
+  _io->_http->print(body);
+  _io->_http->endRequest();
 
   int status = _io->_http->responseStatusCode();
   _io->_http->responseBody(); // needs to be read even if not used
+
   return status == 201;
 }
 

--- a/src/AdafruitIO_Group.cpp
+++ b/src/AdafruitIO_Group.cpp
@@ -283,9 +283,11 @@ void AdafruitIO_Group::setLocation(double lat, double lon, double ele)
 
 bool AdafruitIO_Group::exists()
 {
-  _io->_http->startRequest(_group_url, HTTP_METHOD_GET);
+  _io->_http->beginRequest();
+  _io->_http->get(_group_url);
   _io->_http->sendHeader("X-AIO-Key", _io->_key);
   _io->_http->endRequest();
+
   int status = _io->_http->responseStatusCode();
   _io->_http->responseBody(); // needs to be read even if not used
   return status == 200;
@@ -296,18 +298,26 @@ bool AdafruitIO_Group::create()
   String body = "name=";
   body += name;
 
-  _io->_http->startRequest(_create_url, HTTP_METHOD_POST);
-  _io->_http->sendHeader(HTTP_HEADER_CONTENT_TYPE, "application/x-www-form-urlencoded");
-  _io->_http->sendHeader(HTTP_HEADER_CONTENT_LENGTH, body.length());
+  _io->_http->beginRequest();
+  _io->_http->post(_create_url);
+
+  _io->_http->sendHeader("Content-Type", "application/x-www-form-urlencoded");
+  _io->_http->sendHeader("Content-Length", body.length());
   _io->_http->sendHeader("X-AIO-Key", _io->_key);
+
+  // the following call to endRequest
+  // should be replaced by beginBody once the
+  // Arduino HTTP Client Library is updated
+  // _io->_http->beginBody();
   _io->_http->endRequest();
-  _io->_http->write((const byte*)body.c_str(), body.length());
+
+  _io->_http->print(body);
+  _io->_http->endRequest();
 
   int status = _io->_http->responseStatusCode();
   _io->_http->responseBody(); // needs to be read even if not used
   return status == 201;
 }
-
 
 void AdafruitIO_Group::_init()
 {

--- a/src/blocks/AdafruitIO_Block.cpp
+++ b/src/blocks/AdafruitIO_Block.cpp
@@ -75,12 +75,21 @@ bool AdafruitIO_Block::save()
   body += block_feeds;
   body += "}";
 
-  http->startRequest(url.c_str(), HTTP_METHOD_POST);
-  http->sendHeader(HTTP_HEADER_CONTENT_TYPE, "application/json");
-  http->sendHeader(HTTP_HEADER_CONTENT_LENGTH, body.length());
+  http->beginRequest();
+  http->post(url.c_str());
+
+  http->sendHeader("Content-Type", "application/json");
+  http->sendHeader("Content-Length", body.length());
   http->sendHeader("X-AIO-Key", _dashboard->io()->_key);
+
+  // the following call to endRequest
+  // should be replaced by beginBody once the
+  // Arduino HTTP Client Library is updated
+  // http->beginBody();
   http->endRequest();
-  http->write((const byte*)body.c_str(), body.length());
+
+  http->print(body);
+  http->endRequest();
 
   int status = http->responseStatusCode();
   http->responseBody(); // needs to be read even if not used


### PR DESCRIPTION
this updates group, feed, dashboard, & block classes to support `v0.2.0` of the arduino HTTP client library.  there is an [unreleased `beginBody` API change](https://github.com/arduino-libraries/ArduinoHttpClient/commit/448a1520c892f7667ab11f9aa6141fd9d5376533) that adds request body support. `beginBody` is an alias for `endRequest`, so for now multiple calls to `endRequest` are used to support POST request bodies.