### PR TITLE
Added connection status check before WiFi.begin

### DIFF
--- a/src/wifi/AdafruitIO_ESP8266.cpp
+++ b/src/wifi/AdafruitIO_ESP8266.cpp
@@ -32,12 +32,13 @@ AdafruitIO_ESP8266::~AdafruitIO_ESP8266()
 
 void AdafruitIO_ESP8266::_connect()
 {
-
   delay(100);
-  WiFi.begin(_ssid, _pass);
+  if (networkStatus() < 20) { // only try to connect if ESP8266 isn't already connected
+    WiFi.mode(WIFI_STA); // force ESP8266 into STATION mode (working on AP+STA implementation)
+    WiFi.begin(_ssid, _pass);
+    _status = AIO_NET_DISCONNECTED;
+  }
   delay(100);
-  _status = AIO_NET_DISCONNECTED;
-
 }
 
 aio_status_t AdafruitIO_ESP8266::networkStatus()


### PR DESCRIPTION
During a troubleshooting session on Discord #adafruit-io with @seckela on late 16 November to early 17 November, we discovered that if a WiFi connection is already established, the Adafruit IO library would not proceed past `io.connect()`. I added a `networkStatus()` check before calling `WiFi.begin` to avoid getting stuck in `io.connect()`. 

Also, I added a call to force the ESP8266 into Station mode; I ran into a problem of persistent AP+STA mode and couldn't get out of it.

I didn't add these to any of the other boards (ESP32, etc), but can gladly do so. However, I can't test them as I only have ESP8266s at the moment.