### PR TITLE
Use /get MQTT topic to trigger resend of feed data.

### DIFF
--- a/examples/adafruitio_00_publish/adafruitio_00_publish.ino
+++ b/examples/adafruitio_00_publish/adafruitio_00_publish.ino
@@ -66,7 +66,9 @@ void loop() {
   // increment the count by 1
   count++;
 
-  // wait one second (1000 milliseconds == 1 second)
-  delay(1000);
+  // Adafruit IO is rate limited for publishing, so a delay is required in
+  // between feed->save events. In this example, we will wait three seconds
+  // (1000 milliseconds == 1 second) during each loop.
+  delay(3000);
 
 }

--- a/examples/adafruitio_01_subscribe/adafruitio_01_subscribe.ino
+++ b/examples/adafruitio_01_subscribe/adafruitio_01_subscribe.ino
@@ -51,14 +51,7 @@ void setup() {
 
   // Because Adafruit IO doesn't support the MQTT retain flag, we can use the
   // get() function to ask IO to resend the last value for this feed to just
-  // this MQTT client.
-  //
-  // Behind the scenes, the library is MQTT publishing an empty message to the
-  // {username}/f/counter/csv/get topic to trigger a resend on the
-  // {username}/f/counter/csv topic that this client is already subscribed to.
-  // That means calling get() will cause the handleMessage function we attached
-  // to this feed to be called with the most recent data record published to
-  // the feed.
+  // this MQTT client after the io client is connected.
   counter->get();
 
   // we are connected
@@ -74,6 +67,9 @@ void loop() {
   // function. it keeps the client connected to
   // io.adafruit.com, and processes any incoming data.
   io.run();
+
+  // Because this sketch isn't publishing, we don't need
+  // a delay() in the main program loop.
 
 }
 

--- a/examples/adafruitio_04_location/adafruitio_04_location.ino
+++ b/examples/adafruitio_04_location/adafruitio_04_location.ino
@@ -27,6 +27,11 @@ double lat = 42.331427;
 double lon = -83.045754;
 double ele = 0;
 
+// track time of last published messages and limit feed->save events to once
+// every IO_LOOP_DELAY milliseconds
+#define IO_LOOP_DELAY 5000
+unsigned long lastUpdate;
+
 // set up the 'location' feed
 AdafruitIO_Feed *location = io.feed("location");
 
@@ -55,6 +60,7 @@ void setup() {
   // we are connected
   Serial.println();
   Serial.println(io.statusText());
+  location->get();
 
 }
 
@@ -63,28 +69,30 @@ void loop() {
   // process messages and keep connection alive
   io.run();
 
-  Serial.println("----- sending -----");
-  Serial.print("value: ");
-  Serial.println(value);
-  Serial.print("lat: ");
-  Serial.println(lat, 6);
-  Serial.print("lon: ");
-  Serial.println(lon, 6);
-  Serial.print("ele: ");
-  Serial.println(ele, 2);
+  if (millis() > (lastUpdate + IO_LOOP_DELAY)) {
+    Serial.println("----- sending -----");
+    Serial.print("value: ");
+    Serial.println(value);
+    Serial.print("lat: ");
+    Serial.println(lat, 6);
+    Serial.print("lon: ");
+    Serial.println(lon, 6);
+    Serial.print("ele: ");
+    Serial.println(ele, 2);
 
-  // save value and location data to the
-  // 'location' feed on Adafruit IO
-  location->save(value, lat, lon, ele);
+    // save value and location data to the
+    // 'location' feed on Adafruit IO
+    location->save(value, lat, lon, ele);
 
- // shift all values (for demo purposes)
-  value += 1;
-  lat -= 0.01;
-  lon += 0.02;
-  ele += 1;
+    // shift all values (for demo purposes)
+    value += 1;
+    lat -= 0.01;
+    lon += 0.02;
+    ele += 1;
 
-  // wait one second (1000 milliseconds == 1 second)
-  delay(1000);
+    // wait one second (1000 milliseconds == 1 second)
+    lastUpdate = millis();
+  }
 
 }
 

--- a/examples/adafruitio_05_type_conversion/adafruitio_05_type_conversion.ino
+++ b/examples/adafruitio_05_type_conversion/adafruitio_05_type_conversion.ino
@@ -33,6 +33,11 @@ float float_val = 2.4901;
 // set up variable that will allow us to flip between sending types
 int current_type = 0;
 
+// track time of last published messages and limit feed->save events to once
+// every IO_LOOP_DELAY milliseconds
+#define IO_LOOP_DELAY 5000
+unsigned long lastUpdate;
+
 // set up the 'type' feed
 AdafruitIO_Feed *type = io.feed("type");
 
@@ -69,60 +74,61 @@ void loop() {
   // process messages and keep connection alive
   io.run();
 
-  Serial.println("----- sending -----");
+  if (millis() > (lastUpdate + IO_LOOP_DELAY)) {
+    Serial.println("----- sending -----");
 
-  // in order to demonstrate sending values
-  // as different types, we will switch between
-  // types in a loop using the current_type variable
-  if(current_type == 0) {
-    Serial.print("char: ");
-    Serial.println(char_val);
-    type->save(char_val);
-  } else if(current_type == 1) {
-    Serial.print("string: ");
-    Serial.println(string_val);
-    type->save(string_val);
-  } else if(current_type == 2) {
-    Serial.print("bool: ");
-    Serial.println(bool_val);
-    type->save(bool_val);
-  } else if(current_type == 3) {
-    Serial.print("int: ");
-    Serial.println(int_val);
-    type->save(int_val);
-  } else if(current_type == 4) {
-    Serial.print("unsigned int: ");
-    Serial.println(uint_val);
-    type->save(uint_val);
-  } else if(current_type == 5) {
-    Serial.print("long: ");
-    Serial.println(long_val);
-    type->save(long_val);
-  } else if(current_type == 6) {
-    Serial.print("unsigned long: ");
-    Serial.println(ulong_val);
-    type->save(ulong_val);
-  } else if(current_type == 7) {
-    Serial.print("double: ");
-    Serial.println(double_val);
-    type->save(double_val);
-  } else if(current_type == 8) {
-    Serial.print("float: ");
-    Serial.println(float_val);
-    type->save(float_val);
+    // in order to demonstrate sending values
+    // as different types, we will switch between
+    // types in a loop using the current_type variable
+    if(current_type == 0) {
+      Serial.print("char: ");
+      Serial.println(char_val);
+      type->save(char_val);
+    } else if(current_type == 1) {
+      Serial.print("string: ");
+      Serial.println(string_val);
+      type->save(string_val);
+    } else if(current_type == 2) {
+      Serial.print("bool: ");
+      Serial.println(bool_val);
+      type->save(bool_val);
+    } else if(current_type == 3) {
+      Serial.print("int: ");
+      Serial.println(int_val);
+      type->save(int_val);
+    } else if(current_type == 4) {
+      Serial.print("unsigned int: ");
+      Serial.println(uint_val);
+      type->save(uint_val);
+    } else if(current_type == 5) {
+      Serial.print("long: ");
+      Serial.println(long_val);
+      type->save(long_val);
+    } else if(current_type == 6) {
+      Serial.print("unsigned long: ");
+      Serial.println(ulong_val);
+      type->save(ulong_val);
+    } else if(current_type == 7) {
+      Serial.print("double: ");
+      Serial.println(double_val);
+      type->save(double_val);
+    } else if(current_type == 8) {
+      Serial.print("float: ");
+      Serial.println(float_val);
+      type->save(float_val);
+    }
+
+    // move to the next type
+    current_type++;
+
+    // reset type if we have reached the end
+    if(current_type > 8)
+      current_type = 0;
+
+    Serial.println();
+
+    lastUpdate = millis();
   }
-
-  // move to the next type
-  current_type++;
-
-  // reset type if we have reached the end
-  if(current_type > 8)
-    current_type = 0;
-
-  Serial.println();
-
-  // wait two seconds (2000 milliseconds == 2 seconds)
-  delay(2000);
 
 }
 

--- a/examples/adafruitio_07_digital_out/adafruitio_07_digital_out.ino
+++ b/examples/adafruitio_07_digital_out/adafruitio_07_digital_out.ino
@@ -56,6 +56,7 @@ void setup() {
   // we are connected
   Serial.println();
   Serial.println(io.statusText());
+  digital->get();
 
 }
 

--- a/examples/adafruitio_08_analog_in/adafruitio_08_analog_in.ino
+++ b/examples/adafruitio_08_analog_in/adafruitio_08_analog_in.ino
@@ -77,6 +77,9 @@ void loop() {
   // store last photocell state
   last = current;
 
-  // wait one second (1000 milliseconds == 1 second)
-  delay(1000);
+  // wait three seconds (1000 milliseconds == 1 second)
+  //
+  // because there are no active subscriptions, we can use delay()
+  // instead of tracking millis()
+  delay(3000);
 }

--- a/examples/adafruitio_09_analog_out/adafruitio_09_analog_out.ino
+++ b/examples/adafruitio_09_analog_out/adafruitio_09_analog_out.ino
@@ -53,6 +53,7 @@ void setup() {
   // we are connected
   Serial.println();
   Serial.println(io.statusText());
+  analog->get();
 
 }
 

--- a/examples/adafruitio_11_group_pub/adafruitio_11_group_pub.ino
+++ b/examples/adafruitio_11_group_pub/adafruitio_11_group_pub.ino
@@ -71,6 +71,6 @@ void loop() {
   // increment the count_2 by 2
   count_2 *= 2;
 
-  // wait one second (1000 milliseconds == 1 second)
-  delay(1000);
+  // wait four seconds (1000 milliseconds == 1 second)
+  delay(4000);
 }

--- a/examples/adafruitio_13_rgb/adafruitio_13_rgb.ino
+++ b/examples/adafruitio_13_rgb/adafruitio_13_rgb.ino
@@ -56,6 +56,7 @@ void setup() {
   // we are connected
   Serial.println();
   Serial.println(io.statusText());
+  color->get();
 
   // set analogWrite range for ESP8266
   #ifdef ESP8266

--- a/examples/adafruitio_14_neopixel/adafruitio_14_neopixel.ino
+++ b/examples/adafruitio_14_neopixel/adafruitio_14_neopixel.ino
@@ -57,6 +57,7 @@ void setup() {
   // we are connected
   Serial.println();
   Serial.println(io.statusText());
+  color->get();
 
   // neopixel init
   pixels.begin();

--- a/examples/adafruitio_16_servo/adafruitio_16_servo.ino
+++ b/examples/adafruitio_16_servo/adafruitio_16_servo.ino
@@ -61,6 +61,7 @@ void setup() {
   // we are connected
   Serial.println();
   Serial.println(io.statusText());
+  servo_feed->get();
 
 }
 

--- a/src/AdafruitIO.cpp
+++ b/src/AdafruitIO.cpp
@@ -239,10 +239,10 @@ aio_status_t AdafruitIO::mqttStatus()
     case 2:   // client id rejected
     case 4:   // malformed user/pass
     case 5:   // unauthorized
-    case 7:   // banned
       return AIO_CONNECT_FAILED;
-    case 3: // mqtt service unavailable
-    case 6: // throttled
+    case 3:   // mqtt service unavailable
+    case 6:   // throttled
+    case 7:   // banned -> all MQTT bans are temporary, so eventual retry is permitted
       // delay to prevent fast reconnects
       delay(AIO_THROTTLE_RECONNECT_INTERVAL);
       return AIO_DISCONNECTED;

--- a/src/AdafruitIO_Feed.cpp
+++ b/src/AdafruitIO_Feed.cpp
@@ -119,7 +119,7 @@ bool AdafruitIO_Feed::get()
     strcat(_get_topic, name);
     strcat(_get_topic, "/csv/get");
 
-    _get_pub = new Adafruit_MQTT_Publish(_io->_mqtt, _topic);
+    _get_pub = new Adafruit_MQTT_Publish(_io->_mqtt, _get_topic);
   }
 
   return _get_pub->publish('\0');

--- a/src/AdafruitIO_Feed.cpp
+++ b/src/AdafruitIO_Feed.cpp
@@ -31,11 +31,17 @@ AdafruitIO_Feed::~AdafruitIO_Feed()
   if(_pub)
     delete _pub;
 
+  if(_get_pub)
+    delete _pub;
+
   if(data)
     delete data;
 
   if(_topic)
     free(_topic);
+
+  if (_get_topic)
+    free(_get_topic);
 
   if(_feed_url)
     free(_feed_url);
@@ -101,6 +107,22 @@ bool AdafruitIO_Feed::save(double value, double lat, double lon, double ele, int
 {
   data->setValue(value, lat, lon, ele, precision);
   return _pub->publish(data->toCSV());
+}
+
+bool AdafruitIO_Feed::get()
+{
+  if (!_get_topic)
+  {
+    _get_topic = (char *) malloc(sizeof(char) * (strlen(_io->_username) + strlen(name) + 12)); // 12 extra chars for /f/, /csv/get & null termination
+    strcpy(_get_topic, _io->_username);
+    strcat(_get_topic, "/f/");
+    strcat(_get_topic, name);
+    strcat(_get_topic, "/csv/get");
+
+    _get_pub = new Adafruit_MQTT_Publish(_io->_mqtt, _topic);
+  }
+
+  return _get_pub->publish('\0');
 }
 
 bool AdafruitIO_Feed::exists()

--- a/src/AdafruitIO_Feed.cpp
+++ b/src/AdafruitIO_Feed.cpp
@@ -118,7 +118,10 @@ bool AdafruitIO_Feed::get()
     strcat(_get_topic, "/f/");
     strcat(_get_topic, name);
     strcat(_get_topic, "/csv/get");
+  }
 
+  if (!_get_pub)
+  {
     _get_pub = new Adafruit_MQTT_Publish(_io->_mqtt, _get_topic);
   }
 

--- a/src/AdafruitIO_Feed.h
+++ b/src/AdafruitIO_Feed.h
@@ -37,6 +37,8 @@ class AdafruitIO_Feed : public AdafruitIO_MQTT {
     bool save(float value, double lat=0, double lon=0, double ele=0, int precision=6);
     bool save(double value, double lat=0, double lon=0, double ele=0, int precision=6);
 
+    bool get();
+
     bool exists();
     bool create();
 
@@ -56,11 +58,13 @@ class AdafruitIO_Feed : public AdafruitIO_MQTT {
     void _init();
 
     char *_topic;
+    char *_get_topic;
     char *_create_url;
     char *_feed_url;
 
     Adafruit_MQTT_Subscribe *_sub;
     Adafruit_MQTT_Publish *_pub;
+    Adafruit_MQTT_Publish *_get_pub;
 
     AdafruitIO *_io;
     AdafruitIO_Data *_data;


### PR DESCRIPTION
This change adds support for Adafruit IO's new MQTT /get method that retriggers sending of the last value for a given feed. 

Because IO doesn't support the MQTT retain flag we need a different way to recall the last value published to a given feed. This library already includes a `feed->lastValue` method, but that uses the HTTP API, which can be finicky when used in combination with an MQTT connection. By keeping everything in MQTT, application code can be simpler and slightly more robust.