### PR TITLE
Adafruit IO bug fix

### DIFF
--- a/src/AdafruitIO_Data.cpp
+++ b/src/AdafruitIO_Data.cpp
@@ -245,7 +245,7 @@ bool AdafruitIO_Data::toBool()
   if(! _value)
     return false;
 
-  if(strcmp(_value, "1") == 0 || _value[0] == 't' || _value[0] == 'T')
+  if(strcmp(_value, "ON") == 0 || strcmp(_value, "1") == 0 || _value[0] == 't' || _value[0] == 'T')
     return true;
   else
     return false;


### PR DESCRIPTION
The sketch adafruit_io_digital_out does not work properly with Adafruit IO. The value returned by toPinLevel() is always 0 whether I turn on or off the LED.
The reason is that Adafruit IO toggle button feed sends ON and OFF values by default. The API doesn't work with those values so I added the necessary.