### PR TITLE
add prec. points to sending AVR and non-avr (SAMD/ESP32) targets

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit IO Arduino
-version=2.7.22
+version=2.7.23
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library to access Adafruit IO.

--- a/src/AdafruitIO_Data.cpp
+++ b/src/AdafruitIO_Data.cpp
@@ -182,14 +182,14 @@ void AdafruitIO_Data::setValue(float value, double lat, double lon, double ele, 
 
   #if defined(ARDUINO_ARCH_AVR)
     // Use avrlibc dtostre function on AVR platforms.
-    dtostre(value, _value, 10, 0);
+    dtostre(value, _value, precision, 0);
   #elif defined(ESP8266)
     // ESP8266 Arduino only implements dtostrf and not dtostre.  Use dtostrf
     // but accept a hint as to how many decimals of precision are desired.
     dtostrf(value, 0, precision, _value);
   #else
     // Otherwise fall back to snprintf on other platforms.
-    snprintf(_value, sizeof(_value)-1, "%f", value);
+    snprintf(_value, sizeof(_value) - 1, "%0.*f", precision, value);
   #endif
 
   setLocation(lat, lon, ele);
@@ -201,14 +201,14 @@ void AdafruitIO_Data::setValue(double value, double lat, double lon, double ele,
 
   #if defined(ARDUINO_ARCH_AVR)
     // Use avrlibc dtostre function on AVR platforms.
-    dtostre(value, _value, 10, 0);
+    dtostre(value, _value, precision, 0);
   #elif defined(ESP8266)
     // ESP8266 Arduino only implements dtostrf and not dtostre.  Use dtostrf
     // but accept a hint as to how many decimals of precision are desired.
     dtostrf(value, 0, precision, _value);
   #else
     // Otherwise fall back to snprintf on other platforms.
-    snprintf(_value, sizeof(_value)-1, "%f", value);
+    snprintf(_value, sizeof(_value) - 1, "%0.*f", precision, value);
   #endif
 
   setLocation(lat, lon, ele);


### PR DESCRIPTION
Addressing https://github.com/adafruit/Adafruit_IO_Arduino/issues/76: Adding the ability to set the amount of precision points while sending a a double or float to Adafruit IO from non-esp8266 hardware. 