### PR TITLE
Add WPA2 Enterprise support for ESP8266 and ESP32 platforms

### DIFF
--- a/examples/adafruitio_00_publish/config.h
+++ b/examples/adafruitio_00_publish/config.h
@@ -22,8 +22,29 @@
 AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 
 
-/******************************* FONA **************************************/
+/******************************* WIFI WPA2 Enterprise***********************/
 
+// the AdafruitIO_WiFi_Enterprise client will work with the following boards:
+//   - HUZZAH ESP8266 Breakout -> https://www.adafruit.com/products/2471
+//   - Feather HUZZAH ESP8266 -> https://www.adafruit.com/products/2821
+//   - Feather HUZZAH ESP32 -> https://www.adafruit.com/product/3405
+// currently only username/password authentication is supported.
+
+// uncomment the below lines for WPA2 Enterprise
+// and comment out the AdafruitIO_WiFi client in the WIFI section
+
+// It is unclear whether CA certificate validation is functional for either board. I was unable to get it to work.
+
+#include "AdafruitIO_WiFi_Enterprise.h"
+#define WIFI_ENT_SSID  "eduroam"
+#define WIFI_ENT_IDENT "user"
+#define WIFI_ENT_PASS  "password"
+// I was unable to get CA certificate validation to work. Passing NULL disables it.
+#define WIFI_CACERT NULL
+
+AdafruitIO_WiFi_Enterprise io(IO_USERNAME, IO_KEY, WIFI_ENT_SSID, WIFI_ENT_IDENT, WIFI_ENT_PASS, WIFI_CACERT);
+
+/******************************* FONA **************************************/
 // the AdafruitIO_FONA client will work with the following boards:
 //   - Feather 32u4 FONA -> https://www.adafruit.com/product/3027
 

--- a/examples/adafruitio_00_publish/config.h
+++ b/examples/adafruitio_00_publish/config.h
@@ -22,29 +22,8 @@
 AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 
 
-/******************************* WIFI WPA2 Enterprise***********************/
-
-// the AdafruitIO_WiFi_Enterprise client will work with the following boards:
-//   - HUZZAH ESP8266 Breakout -> https://www.adafruit.com/products/2471
-//   - Feather HUZZAH ESP8266 -> https://www.adafruit.com/products/2821
-//   - Feather HUZZAH ESP32 -> https://www.adafruit.com/product/3405
-// currently only username/password authentication is supported.
-
-// uncomment the below lines for WPA2 Enterprise
-// and comment out the AdafruitIO_WiFi client in the WIFI section
-
-// It is unclear whether CA certificate validation is functional for either board. I was unable to get it to work.
-
-#include "AdafruitIO_WiFi_Enterprise.h"
-#define WIFI_ENT_SSID  "eduroam"
-#define WIFI_ENT_IDENT "user"
-#define WIFI_ENT_PASS  "password"
-// I was unable to get CA certificate validation to work. Passing NULL disables it.
-#define WIFI_CACERT NULL
-
-AdafruitIO_WiFi_Enterprise io(IO_USERNAME, IO_KEY, WIFI_ENT_SSID, WIFI_ENT_IDENT, WIFI_ENT_PASS, WIFI_CACERT);
-
 /******************************* FONA **************************************/
+
 // the AdafruitIO_FONA client will work with the following boards:
 //   - Feather 32u4 FONA -> https://www.adafruit.com/product/3027
 
@@ -63,3 +42,24 @@ AdafruitIO_WiFi_Enterprise io(IO_USERNAME, IO_KEY, WIFI_ENT_SSID, WIFI_ENT_IDENT
 // and comment out the AdafruitIO_WiFi client in the WIFI section
 // #include "AdafruitIO_Ethernet.h"
 // AdafruitIO_Ethernet io(IO_USERNAME, IO_KEY);
+
+
+/******************************* WIFI WPA2 Enterprise *********************/
+
+// the AdafruitIO_WiFi_Enterprise client will work with the following boards:
+//   - HUZZAH ESP8266 Breakout -> https://www.adafruit.com/products/2471
+//   - Feather HUZZAH ESP8266 -> https://www.adafruit.com/products/2821
+//   - Feather HUZZAH ESP32 -> https://www.adafruit.com/product/3405
+// currently only username/password authentication is supported.
+
+// It is unclear whether CA certificate validation is functional for either board.
+
+// uncomment the below lines for WPA2 Enterprise
+// and comment out the AdafruitIO_WiFi client in the WIFI section
+
+// #include "AdafruitIO_WiFi_Enterprise.h"
+// #define WIFI_ENT_SSID  "eduroam"
+// #define WIFI_ENT_IDENT "user"
+// #define WIFI_ENT_PASS  "password"
+// #define WIFI_CACERT NULL // passing NULL disables CA certificate validation, which does not appear to work
+// AdafruitIO_WiFi_Enterprise io(IO_USERNAME, IO_KEY, WIFI_ENT_SSID, WIFI_ENT_IDENT, WIFI_ENT_PASS, WIFI_CACERT);

--- a/src/AdafruitIO_WiFi_Enterprise.h
+++ b/src/AdafruitIO_WiFi_Enterprise.h
@@ -1,0 +1,27 @@
+//
+// Adafruit invests time and resources providing this open source code.
+// Please support Adafruit and open source hardware by purchasing
+// products from Adafruit!
+//
+// Copyright (c) 2015-2019 Adafruit Industries
+// Authors: Tony DiCola, Todd Treece, David Ryskalczyk
+// Licensed under the MIT license.
+//
+// All text above must be included in any redistribution.
+//
+#ifndef ADAFRUITIO_WIFI_ENTERPRISE_H
+#define ADAFRUITIO_WIFI_ENTERPRISE_H
+
+#if defined(ARDUINO_ARCH_ESP32)
+
+  #include "wifi/AdafruitIO_ESP32_Enterprise.h"
+  typedef AdafruitIO_ESP32_Enterprise AdafruitIO_WiFi_Enterprise;
+
+#elif defined(ESP8266)
+
+  #include "wifi/AdafruitIO_ESP8266_Enterprise.h"
+  typedef AdafruitIO_ESP8266_Enterprise AdafruitIO_WiFi_Enterprise;
+
+#endif
+
+#endif // ADAFRUITIO_WIFI_ENTERPRISE_H

--- a/src/wifi/AdafruitIO_ESP32_Enterprise.cpp
+++ b/src/wifi/AdafruitIO_ESP32_Enterprise.cpp
@@ -1,0 +1,47 @@
+//
+// Adafruit invests time and resources providing this open source code.
+// Please support Adafruit and open source hardware by purchasing
+// products from Adafruit!
+//
+// Copyright (c) 2015-2019 Adafruit Industries
+// Authors: Tony DiCola, Todd Treece, David Ryskalczyk
+// Licensed under the MIT license.
+//
+// All text above must be included in any redistribution.
+//
+#ifdef ARDUINO_ARCH_ESP32
+
+#include "AdafruitIO_ESP32_Enterprise.h"
+
+AdafruitIO_ESP32_Enterprise::AdafruitIO_ESP32_Enterprise(const char *user, const char *key, const char *ssid, const char *identity, const char *pass, const char *ca_pem) : AdafruitIO_ESP32(user, key, ssid, pass)
+{
+    _identity = identity;
+    _ca_pem = ca_pem;
+}
+
+AdafruitIO_ESP32_Enterprise::~AdafruitIO_ESP32_Enterprise()
+{
+}
+
+void AdafruitIO_ESP32_Enterprise::_connect()
+{
+
+  delay(100);
+  WiFi.mode(WIFI_STA); // set to station mode
+
+  if(_ca_pem != NULL) {
+    esp_wifi_sta_wpa2_ent_set_ca_cert((uint8_t *)_ca_pem, strlen(_ca_pem)); // provide CA certificate, this is necessary for security
+  }
+
+  esp_wifi_sta_wpa2_ent_set_identity((uint8_t *)_identity, strlen(_identity)); //provide identity
+  esp_wifi_sta_wpa2_ent_set_username((uint8_t *)_identity, strlen(_identity)); //provide username --> identity and username is same
+  esp_wifi_sta_wpa2_ent_set_password((uint8_t *)_pass, strlen(_pass)); //provide password
+  esp_wpa2_config_t config = WPA2_CONFIG_INIT_DEFAULT(); //set config settings to default for WPA2
+  esp_wifi_sta_wpa2_ent_enable(&config); // pass WPA2 config to the stack
+  WiFi.begin(_ssid);
+  delay(100);
+  _status = AIO_NET_DISCONNECTED;
+
+}
+
+#endif // ARDUINO_ARCH_ESP32

--- a/src/wifi/AdafruitIO_ESP32_Enterprise.h
+++ b/src/wifi/AdafruitIO_ESP32_Enterprise.h
@@ -1,0 +1,43 @@
+//
+// Adafruit invests time and resources providing this open source code.
+// Please support Adafruit and open source hardware by purchasing
+// products from Adafruit!
+//
+// Copyright (c) 2015-2019 Adafruit Industries
+// Authors: Tony DiCola, Todd Treece, David Ryskalczyk
+// Licensed under the MIT license.
+//
+// All text above must be included in any redistribution.
+//
+#ifndef ADAFRUITIO_ESP32_ENTERPRISE_H
+#define ADAFRUITIO_ESP32_ENTERPRISE_H
+
+#ifdef ARDUINO_ARCH_ESP32
+
+#include "Arduino.h"
+#include "AdafruitIO.h"
+#include <WiFi.h>
+#include "esp_wpa2.h"
+#include "WiFiClientSecure.h"
+#include "Adafruit_MQTT.h"
+#include "Adafruit_MQTT_Client.h"
+
+#include "wifi/AdafruitIO_ESP32.h"
+
+class AdafruitIO_ESP32_Enterprise : public AdafruitIO_ESP32 {
+
+  public:
+    AdafruitIO_ESP32_Enterprise(const char *user, const char *key, const char *ssid, const char *identity, const char *pass, const char *ca_pem);
+    ~AdafruitIO_ESP32_Enterprise();
+
+  protected:
+
+    void _connect();
+
+    const char *_identity;
+    const char *_ca_pem;
+
+};
+
+#endif //ESP32
+#endif // ADAFRUITIO_ESP32_ENTERPRISE_H

--- a/src/wifi/AdafruitIO_ESP8266_Enterprise.cpp
+++ b/src/wifi/AdafruitIO_ESP8266_Enterprise.cpp
@@ -1,0 +1,48 @@
+//
+// Adafruit invests time and resources providing this open source code.
+// Please support Adafruit and open source hardware by purchasing
+// products from Adafruit!
+//
+// Copyright (c) 2015-2019 Adafruit Industries
+// Authors: Tony DiCola, Todd Treece, David Ryskalczyk
+// Licensed under the MIT license.
+//
+// All text above must be included in any redistribution.
+//
+#ifdef ESP8266
+
+#include "AdafruitIO_ESP8266_Enterprise.h"
+
+AdafruitIO_ESP8266_Enterprise::AdafruitIO_ESP8266_Enterprise(const char *user, const char *key, const char *ssid, const char *identity, const char *pass, const char *ca_pem) : AdafruitIO_ESP8266(user, key, ssid, pass)
+{
+  _identity = identity;
+  _ca_pem = ca_pem;
+}
+
+AdafruitIO_ESP8266_Enterprise::~AdafruitIO_ESP8266_Enterprise()
+{
+}
+
+void AdafruitIO_ESP8266_Enterprise::_connect()
+{
+
+  delay(100);
+  WiFi.mode(WIFI_STA);
+
+  if (_ca_pem != NULL) {
+    wifi_station_set_enterprise_ca_cert((uint8_t *)_ca_pem, strlen(_ca_pem));
+  }
+  wifi_station_set_wpa2_enterprise_auth(1); // enable WPA2 authentication mode
+
+  wifi_station_set_enterprise_identity((uint8_t *)_identity, strlen(_identity)); //provide identity
+  wifi_station_set_enterprise_username((uint8_t *)_identity, strlen(_identity)); //provide username --> identity and username is same
+  wifi_station_set_enterprise_password((uint8_t *)_pass, strlen(_pass)); //provide password
+
+  WiFi.begin(_ssid);
+
+  delay(100);
+  _status = AIO_NET_DISCONNECTED;
+
+}
+
+#endif // ESP8266

--- a/src/wifi/AdafruitIO_ESP8266_Enterprise.h
+++ b/src/wifi/AdafruitIO_ESP8266_Enterprise.h
@@ -1,0 +1,42 @@
+//
+// Adafruit invests time and resources providing this open source code.
+// Please support Adafruit and open source hardware by purchasing
+// products from Adafruit!
+//
+// Copyright (c) 2015-2019 Adafruit Industries
+// Authors: Tony DiCola, Todd Treece, David Ryskalczyk
+// Licensed under the MIT license.
+//
+// All text above must be included in any redistribution.
+//
+#ifndef ADAFRUITIO_ESP8266_ENTERPRISE_H
+#define ADAFRUITIO_ESP8266_ENTERPRISE_H
+
+#ifdef ESP8266
+
+#include "Arduino.h"
+#include "AdafruitIO.h"
+#include "ESP8266WiFi.h"
+#include "WiFiClientSecure.h"
+#include "Adafruit_MQTT.h"
+#include "Adafruit_MQTT_Client.h"
+
+#include "wifi/AdafruitIO_ESP8266.h"
+#include "wpa2_enterprise.h"
+
+class AdafruitIO_ESP8266_Enterprise : public AdafruitIO_ESP8266 {
+
+  public:
+    AdafruitIO_ESP8266_Enterprise(const char *user, const char *key, const char *ssid, const char *identity, const char *pass, const char *ca_pem);
+    ~AdafruitIO_ESP8266_Enterprise();
+
+  protected:
+    void _connect();
+
+    const char *_identity;
+    const char *_ca_pem;
+
+};
+
+#endif //ESP8266
+#endif // ADAFRUITIO_ESP8266_ENTERPRISE_H


### PR DESCRIPTION
Scope of changes:
This PR adds support for WPA2 Enterprise authentication using username/password, as is very common at universities. As some universities don't provide PSK-based wireless authentication, this is critical to make AdafruitIO usable in such environments.

Known limitations:
Only ESP8266 and ESP32 platforms are supported. It does not appear that the other platforms that AdafruitIO supports have exposed methods to enable WPA2 Enterprise authentication.

It does not appear that CA certificate validation is functioning correctly in either the ESP8266 or the ESP32 stack, but it is possible I am passing the wrong certificate.

Testing: No changes have been made to the existing non-Enterprise WiFi code. This has been tested on both ESP8266 and ESP32 hardware.

Only one of the examples has been modified. If this PR is satisfactory, all the examples can be modified as needed.