### PR TITLE
Examples use WIFININA Pin Names

### DIFF
--- a/examples/adafruitio_00_publish/config.h
+++ b/examples/adafruitio_00_publish/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_01_subscribe/config.h
+++ b/examples/adafruitio_01_subscribe/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID "your_ssid"
 #define WIFI_PASS "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_03_multiple_feeds/config.h
+++ b/examples/adafruitio_03_multiple_feeds/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_04_location/config.h
+++ b/examples/adafruitio_04_location/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_05_type_conversion/config.h
+++ b/examples/adafruitio_05_type_conversion/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_06_digital_in/config.h
+++ b/examples/adafruitio_06_digital_in/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_07_digital_out/config.h
+++ b/examples/adafruitio_07_digital_out/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_08_analog_in/config.h
+++ b/examples/adafruitio_08_analog_in/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_09_analog_out/config.h
+++ b/examples/adafruitio_09_analog_out/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_10_dashboard_creation/config.h
+++ b/examples/adafruitio_10_dashboard_creation/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_11_group_pub/config.h
+++ b/examples/adafruitio_11_group_pub/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_12_group_sub/config.h
+++ b/examples/adafruitio_12_group_sub/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_13_rgb/config.h
+++ b/examples/adafruitio_13_rgb/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_14_neopixel/config.h
+++ b/examples/adafruitio_14_neopixel/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_15_temp_humidity/config.h
+++ b/examples/adafruitio_15_temp_humidity/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_16_servo/config.h
+++ b/examples/adafruitio_16_servo/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_17_time_subscribe/config.h
+++ b/examples/adafruitio_17_time_subscribe/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_18_device_info/config.h
+++ b/examples/adafruitio_18_device_info/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_19_deepsleep/config.h
+++ b/examples/adafruitio_19_deepsleep/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_20_shared_feed_write/config.h
+++ b/examples/adafruitio_20_shared_feed_write/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_21_feed_read/config.h
+++ b/examples/adafruitio_21_feed_read/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_22_environmental_monitor/config.h
+++ b/examples/adafruitio_22_environmental_monitor/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_23_ifttt/config.h
+++ b/examples/adafruitio_23_ifttt/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/adafruitio_24_zapier/config.h
+++ b/examples/adafruitio_24_zapier/config.h
@@ -16,6 +16,8 @@
 //   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
 //   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
 //   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
 #define WIFI_SSID   "your_ssid"
 #define WIFI_PASS   "your_pass"
@@ -35,11 +37,11 @@
     // Don't change the names of these #define's! they match the variant ones
     #define SPIWIFI SPI
     #define SPIWIFI_SS 10  // Chip select pin
-    #define SPIWIFI_ACK 9  // a.k.a BUSY or READY pin
-    #define ESP32_RESETN 6 // Reset pin
-    #define ESP32_GPIO0 -1 // Not connected
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
   #endif
-  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, SPIWIFI_ACK, ESP32_RESETN, ESP32_GPIO0, &SPIWIFI);
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
 #else
   AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 #endif

--- a/examples/io_home_series/io_garage/config.h
+++ b/examples/io_home_series/io_garage/config.h
@@ -2,8 +2,8 @@
 
 // visit io.adafruit.com if you need to create an account,
 // or if you need your Adafruit IO key.
-#define IO_USERNAME    "YOUR_AIO_USERNAME"
-#define IO_KEY         "YOUR_AIO_KEY"
+#define IO_USERNAME   "your_username"
+#define IO_KEY        "your_key"
 
 /******************************* WIFI **************************************/
 
@@ -13,15 +13,38 @@
 //   - Feather HUZZAH ESP32 -> https://www.adafruit.com/product/3405
 //   - Feather M0 WiFi -> https://www.adafruit.com/products/3010
 //   - Feather WICED -> https://www.adafruit.com/products/3056
+//   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
+//   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
+//   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
-#define WIFI_SSID       "YOUR_WIFI_SSID"
-#define WIFI_PASS       "YOUR_WIFI_PASSWORD"
+#define WIFI_SSID   "your_ssid"
+#define WIFI_PASS   "your_pass"
 
-// comment out the following two lines if you are using fona or ethernet
+// uncomment the following line if you are using airlift
+// #define USE_AIRLIFT
+
+// uncomment the following line if you are using winc1500
+// #define USE_WINC1500
+
+// comment out the following lines if you are using fona or ethernet
 #include "AdafruitIO_WiFi.h"
-AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 
-
+#if defined(USE_AIRLIFT) || defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE)
+  // Configure the pins used for the ESP32 connection
+  #if !defined(SPIWIFI_SS) // if the wifi definition isnt in the board variant
+    // Don't change the names of these #define's! they match the variant ones
+    #define SPIWIFI SPI
+    #define SPIWIFI_SS 10  // Chip select pin
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
+  #endif
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
+#else
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
+#endif
 /******************************* FONA **************************************/
 
 // the AdafruitIO_FONA client will work with the following boards:
@@ -31,7 +54,6 @@ AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 // and comment out the AdafruitIO_WiFi client in the WIFI section
 // #include "AdafruitIO_FONA.h"
 // AdafruitIO_FONA io(IO_USERNAME, IO_KEY);
-
 
 /**************************** ETHERNET ************************************/
 

--- a/examples/io_home_series/io_home_security/config.h
+++ b/examples/io_home_series/io_home_security/config.h
@@ -2,25 +2,49 @@
 
 // visit io.adafruit.com if you need to create an account,
 // or if you need your Adafruit IO key.
-#define IO_USERNAME    "YOUR_AIO_USERNAME"
-#define IO_KEY "YOUR_AIO_KEY"
+#define IO_USERNAME   "your_username"
+#define IO_KEY        "your_key"
 
 /******************************* WIFI **************************************/
 
 // the AdafruitIO_WiFi client will work with the following boards:
 //   - HUZZAH ESP8266 Breakout -> https://www.adafruit.com/products/2471
 //   - Feather HUZZAH ESP8266 -> https://www.adafruit.com/products/2821
+//   - Feather HUZZAH ESP32 -> https://www.adafruit.com/product/3405
 //   - Feather M0 WiFi -> https://www.adafruit.com/products/3010
 //   - Feather WICED -> https://www.adafruit.com/products/3056
+//   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
+//   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
+//   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
-#define WIFI_SSID       "YOUR_WIFI_SSID"
-#define WIFI_PASS       "YOUR_WIFI_PASS"
+#define WIFI_SSID   "your_ssid"
+#define WIFI_PASS   "your_pass"
 
-// comment out the following two lines if you are using fona or ethernet
+// uncomment the following line if you are using airlift
+// #define USE_AIRLIFT
+
+// uncomment the following line if you are using winc1500
+// #define USE_WINC1500
+
+// comment out the following lines if you are using fona or ethernet
 #include "AdafruitIO_WiFi.h"
-AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 
-
+#if defined(USE_AIRLIFT) || defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE)
+  // Configure the pins used for the ESP32 connection
+  #if !defined(SPIWIFI_SS) // if the wifi definition isnt in the board variant
+    // Don't change the names of these #define's! they match the variant ones
+    #define SPIWIFI SPI
+    #define SPIWIFI_SS 10  // Chip select pin
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
+  #endif
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
+#else
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
+#endif
 /******************************* FONA **************************************/
 
 // the AdafruitIO_FONA client will work with the following boards:
@@ -30,7 +54,6 @@ AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 // and comment out the AdafruitIO_WiFi client in the WIFI section
 // #include "AdafruitIO_FONA.h"
 // AdafruitIO_FONA io(IO_USERNAME, IO_KEY);
-
 
 /**************************** ETHERNET ************************************/
 

--- a/examples/io_home_series/neopixel_and_thermometer/config.h
+++ b/examples/io_home_series/neopixel_and_thermometer/config.h
@@ -2,8 +2,8 @@
 
 // visit io.adafruit.com if you need to create an account,
 // or if you need your Adafruit IO key.
-#define IO_USERNAME    "your_username"
-#define IO_KEY         "your_key"
+#define IO_USERNAME   "your_username"
+#define IO_KEY        "your_key"
 
 /******************************* WIFI **************************************/
 
@@ -13,15 +13,38 @@
 //   - Feather HUZZAH ESP32 -> https://www.adafruit.com/product/3405
 //   - Feather M0 WiFi -> https://www.adafruit.com/products/3010
 //   - Feather WICED -> https://www.adafruit.com/products/3056
+//   - Adafruit PyPortal -> https://www.adafruit.com/product/4116
+//   - Adafruit Metro M4 Express AirLift Lite -> https://www.adafruit.com/product/4000
+//   - Adafruit AirLift Breakout -> https://www.adafruit.com/product/4201
+//   - Adafruit AirLift Shield -> https://www.adafruit.com/product/4285
+//   - Adafruit AirLift FeatherWing -> https://www.adafruit.com/product/4264
 
-#define WIFI_SSID       "your_ssid"
-#define WIFI_PASS       "your_pass"
+#define WIFI_SSID   "your_ssid"
+#define WIFI_PASS   "your_pass"
 
-// comment out the following two lines if you are using fona or ethernet
+// uncomment the following line if you are using airlift
+// #define USE_AIRLIFT
+
+// uncomment the following line if you are using winc1500
+// #define USE_WINC1500
+
+// comment out the following lines if you are using fona or ethernet
 #include "AdafruitIO_WiFi.h"
-AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 
-
+#if defined(USE_AIRLIFT) || defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE)
+  // Configure the pins used for the ESP32 connection
+  #if !defined(SPIWIFI_SS) // if the wifi definition isnt in the board variant
+    // Don't change the names of these #define's! they match the variant ones
+    #define SPIWIFI SPI
+    #define SPIWIFI_SS 10  // Chip select pin
+    #define NINA_ACK 9    // a.k.a BUSY or READY pin
+    #define NINA_RESETN 6 // Reset pin
+    #define NINA_GPIO0 -1 // Not connected
+  #endif
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS, SPIWIFI_SS, NINA_ACK, NINA_RESETN, NINA_GPIO0, &SPIWIFI);
+#else
+  AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
+#endif
 /******************************* FONA **************************************/
 
 // the AdafruitIO_FONA client will work with the following boards:
@@ -31,7 +54,6 @@ AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);
 // and comment out the AdafruitIO_WiFi client in the WIFI section
 // #include "AdafruitIO_FONA.h"
 // AdafruitIO_FONA io(IO_USERNAME, IO_KEY);
-
 
 /**************************** ETHERNET ************************************/
 

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=Adafruit IO Arduino
-version=3.2.0
+version=3.2.1
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library to access Adafruit IO.
-paragraph=Arduino library to access Adafruit IO using the Adafruit ESP8266, ESP32, M0 WINC1500, WICED, MKR1000, Ethernet, or FONA hardware.
+paragraph=Arduino library to access Adafruit IO using the Adafruit AirLift, ESP8266, ESP32, M0 WINC1500, WICED, MKR1000, Ethernet, or FONA hardware.
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*


### PR DESCRIPTION
Adafruit SAMD AirLift boards have redefinitions to use nina pin naming (via https://github.com/adafruit/ArduinoCore-samd/pull/131).

This pull request:
* Updates all example `config.h` files for compatibility with both Adafruit AirLift boards and Arduino WiFi boards (MKR1010/Uno WiFi Rev2), fixing https://github.com/adafruit/Adafruit_IO_Arduino/issues/90
* Updates all example `config.h` files with links to new Adafruit AirLift Shield and Feather product URLs