### PR TITLE
Add support for float formatting on Arduino UNO Wifi Rev. 2

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit IO Arduino
-version=3.2.2
+version=3.2.3
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library to access Adafruit IO.

--- a/src/AdafruitIO_Data.cpp
+++ b/src/AdafruitIO_Data.cpp
@@ -180,7 +180,7 @@ void AdafruitIO_Data::setValue(float value, double lat, double lon, double ele, 
 {
   memset(_value, 0, AIO_DATA_LENGTH);
 
-  #if defined(ARDUINO_ARCH_AVR)
+  #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
     // Use avrlibc dtostre function on AVR platforms.
     dtostre(value, _value, precision, 0);
   #elif defined(ESP8266)
@@ -199,7 +199,7 @@ void AdafruitIO_Data::setValue(double value, double lat, double lon, double ele,
 {
   memset(_value, 0, AIO_DATA_LENGTH);
 
-  #if defined(ARDUINO_ARCH_AVR)
+  #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
     // Use avrlibc dtostre function on AVR platforms.
     dtostre(value, _value, precision, 0);
   #elif defined(ESP8266)
@@ -429,7 +429,7 @@ char* AdafruitIO_Data::charFromDouble(double d, int precision)
 {
   memset(_double_buffer, 0, sizeof(_double_buffer));
 
-  #if defined(ARDUINO_ARCH_AVR)
+  #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
     // Use avrlibc dtostre function on AVR platforms.
     dtostre(d, _double_buffer, 10, 0);
   #elif defined(ESP8266)


### PR DESCRIPTION
This PR adds support for float formatting on Arduino UNO Wifi Rev. 2.
Since that Arduino variant uses the "megaAVR" core, which has much of the same limitations as regular AVR cores, the `ARDUINO_ARCH_AVR` preprocessor check wasn't sufficient to catch this.

This issue was discovered by using said board to post decimal values to Adafruit IO.

Note: This does _not_ add support for board type and board ID - these will still be "unknown" as today.