### PR TITLE
Fix Actions Badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Adafruit IO Arduino Library
 
-![Build Status](https://github.com/adafruit/Adafruit_IO_Arduino/workflows/Arduino%20Library%20CI/badge.svg)
+[![Build Status](https://github.com/adafruit/Adafruit_IO_Arduino/workflows/Arduino%20Library%20CI/badge.svg)](https://github.com/adafruit/Adafruit_IO_Arduino/actions)
 
 [![Discord](https://img.shields.io/discord/327254708534116352.svg)](https://discord.gg/nBQh6qu)
 


### PR DESCRIPTION
Fix badge to link to `repo/actions` URL instead of a static .svg image url