### PR TITLE
Fix hang on connect for AirLift Co-Processors 

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit IO Arduino
-version=3.5.1
+version=3.6.0
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library to access Adafruit IO.

--- a/src/wifi/AdafruitIO_AIRLIFT.h
+++ b/src/wifi/AdafruitIO_AIRLIFT.h
@@ -156,7 +156,6 @@ protected:
     if (strlen(_ssid) == 0) {
       _status = AIO_SSID_INVALID;
     } else {
-      _disconnect();
       // setup ESP32 pins
       if (_ssPin != -1) {
         WiFi.setPins(_ssPin, _ackPin, _rstPin, _gpio0Pin, _wifi);
@@ -164,6 +163,9 @@ protected:
 
       // check esp32 module version against NINAFWVER
       firmwareCheck();
+
+      // disconnect from possible previous connection
+      _disconnect();
 
       // check for esp32 module
       if (WiFi.status() == WL_NO_MODULE) {


### PR DESCRIPTION
Fixes hang for AirLift Co-Processors during connect introduced in [3.3.1](https://github.com/adafruit/Adafruit_IO_Arduino/releases/tag/3.3.1).

Relevant Forum Issues:
https://forums.adafruit.com/viewtopic.php?f=56&t=164725
https://forums.adafruit.com/viewtopic.php?f=56&t=164620

---
Tested on Feather M4 and FeatherWing AirLift

Previous (v`3.5.1`) hang:
```
Connecting to Adafruit IO
1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1.
```

This PR (v`3.6.0`): 
```
Connecting to Adafruit IO
Adafruit IO connected.
sending -> 0
....
sending -> 200
```


