### PR TITLE
Don't compare nullptr string - Fixes #120

### DIFF
--- a/src/AdafruitIO_Group.cpp
+++ b/src/AdafruitIO_Group.cpp
@@ -345,7 +345,7 @@ void AdafruitIO_Group::call(AdafruitIO_Data *d) {
 
   while (cur_cb) {
 
-    if (strcmp(cur_cb->feed, d->feedName()) == 0 || cur_cb->feed == NULL) {
+    if (cur_cb->feed == NULL || strcmp(cur_cb->feed, d->feedName()) == 0) {
       cur_cb->dataCallback(d);
     }
 


### PR DESCRIPTION
In AdafruitIO_Group::call there is a comparison with the feedname
of the update. If the onMessage() call didn't provide a feed name,
the feed pointer is null.  The code also checks for this, but
it does it after comparing with a string.  Reverse the check
so a short-circuiting or can do the right thing.
