### PR TITLE
AdafruitIO_Group: compare feed names case-insensitively

### DIFF
--- a/src/AdafruitIO_Group.cpp
+++ b/src/AdafruitIO_Group.cpp
@@ -231,6 +231,20 @@ bool AdafruitIO_Group::save() {
 bool AdafruitIO_Group::get() { return _get_pub->publish("\0"); }
 
 /**************************************************************************/
+/*
+    @brief    Helper function to compare strings case-insensitively
+    @return   True if strings are equal (ignoring case)
+*/
+/**************************************************************************/
+bool strsame_nocase(const char *str1, const char *str2) {
+  while ( *str1 && *str2 && tolower(*str1) == tolower(*str2) ) {
+    ++str1;
+    ++str2;
+  }
+  return tolower(*str1) == tolower(*str2);
+}
+
+/**************************************************************************/
 /*!
     @brief    Obtains data from feed within group.
     @param    feed
@@ -251,7 +265,7 @@ AdafruitIO_Data *AdafruitIO_Group::getFeed(const char *feed) {
 
   while (cur_data != NULL) {
 
-    if (strcmp(cur_data->feedName(), feed) == 0) {
+    if (strsame_nocase(cur_data->feedName(), feed)) {
       return cur_data;
     }
 
@@ -314,7 +328,7 @@ void AdafruitIO_Group::onMessage(const char *feed,
 
   while (cur_cb != NULL) {
 
-    if (strcmp(cur_cb->feed, feed) == 0) {
+    if (strsame_nocase(cur_cb->feed, feed)) {
       return;
     }
 
@@ -345,7 +359,7 @@ void AdafruitIO_Group::call(AdafruitIO_Data *d) {
 
   while (cur_cb) {
 
-    if (cur_cb->feed == NULL || strcmp(cur_cb->feed, d->feedName()) == 0) {
+    if (cur_cb->feed == NULL || strsame_nocase(cur_cb->feed, d->feedName())) {
       cur_cb->dataCallback(d);
     }
 


### PR DESCRIPTION
Feeds are matched with a case-sensitive search when adding new feed
data to a Group.  This can cause different values to be published
for the same feed in a single call to save() in a way that's not
easy to see from the code.

Avoid the problem by matching feeds case-insensitively when searching
for existing feeds in the Group data list.

Note: I added the new `strcmp_nocase` function inline in the
AdafruitIO_Group.cpp module since I didn't see any clear place to put
these kinds of utility functions in the library.  I'm open to moving
it, renaming, restructuring it or whatever.  Perhaps a better option
is to use the `String::equalsIgnoreCase()`, but constructing String
temporaries for each comparison seemed excessive to me.

Fixes #123

