### PR TITLE
Add _disconnect function to AdafruitIO_FONA.h

### DIFF
--- a/src/AdafruitIO_FONA.h
+++ b/src/AdafruitIO_FONA.h
@@ -130,10 +130,10 @@ protected:
   */
   /**************************************************************************/
   void _disconnect() {
-      if (!_fona->enableGPRS(false)) {
-          AIO_DEBUG_PRINTLN("Failed to turn off GPRS.");
-      }
-      _status = AIO_NET_DISCONNECTED;
+    if (!_fona->enableGPRS(false)) {
+      AIO_DEBUG_PRINTLN("Failed to turn off GPRS.");
+    }
+    _status = AIO_NET_DISCONNECTED;
   }
 };
 

--- a/src/AdafruitIO_FONA.h
+++ b/src/AdafruitIO_FONA.h
@@ -123,6 +123,18 @@ protected:
 
     _status = AIO_NET_DISCONNECTED;
   }
+
+  /**************************************************************************/
+  /*!
+      @brief  Disconnects from Adafruit IO and the cellular network.
+  */
+  /**************************************************************************/
+  void _disconnect() {
+      if (!_fona->enableGPRS(false)) {
+          AIO_DEBUG_PRINTLN("Failed to turn off GPRS.");
+      }
+      _status = AIO_NET_DISCONNECTED;
+  }
 };
 
 #endif // ADAFRUITIO_FONA_H


### PR DESCRIPTION
Related: https://github.com/adafruit/Adafruit_IO_Arduino/issues/134

Adding _disconnect function which disables GPRS and sets AIO network `_status`

NOTE: This PR is currently untested on hardware and is a draft pull request, will test tomorrow. 