### PR TITLE
Added support for the MKR1010

### DIFF
--- a/src/AdafruitIO_WiFi.h
+++ b/src/AdafruitIO_WiFi.h
@@ -7,7 +7,7 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Written by Tony DiCola, Todd Treece for Adafruit Industries
+ * Written by Tony DiCola, Todd Treece, Morgan Winters for Adafruit Industries
  *
  * BSD license, all text here must be included in any redistribution.
  *
@@ -19,6 +19,11 @@
 
 #include "wifi/AdafruitIO_MKR1000.h"
 typedef AdafruitIO_MKR1000 AdafruitIO_WiFi;
+
+#elif defined(ARDUINO_SAMD_MKR1010)
+
+#include "wifi/AdafruitIO_MKR1010.h"
+typedef AdafruitIO_MKR1010 AdafruitIO_WiFi;
 
 #elif defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) || defined(ADAFRUIT_PYPORTAL) || \
     defined(USE_AIRLIFT)

--- a/src/AdafruitIO_WiFi.h
+++ b/src/AdafruitIO_WiFi.h
@@ -7,7 +7,7 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Written by Tony DiCola, Todd Treece, Morgan Winters for Adafruit Industries
+ * Written by Tony DiCola, Todd Treece for Adafruit Industries
  *
  * BSD license, all text here must be included in any redistribution.
  *

--- a/src/wifi/AdafruitIO_MKR1010.cpp
+++ b/src/wifi/AdafruitIO_MKR1010.cpp
@@ -1,0 +1,77 @@
+/*!
+ * @file AdafruitIO_MKR1010.cpp
+ *
+ * Adafruit invests time and resources providing this open source code.
+ * Please support Adafruit and open source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) 2015-2016 Adafruit Industries
+ * Authors: Tony DiCola, Todd Treece, Morgan Winters
+ * Licensed under the MIT license.
+ *
+ * All text above must be included in any redistribution.
+ */
+
+#if defined(ARDUINO_SAMD_MKR1010)
+
+#include "AdafruitIO_MKR1010.h"
+
+AdafruitIO_MKR1010::AdafruitIO_MKR1010(const char *user, const char *key,
+                                       const char *ssid, const char *pass)
+    : AdafruitIO(user, key) {
+  _ssid = ssid;
+  _pass = pass;
+  _client = new WiFiSSLClient;
+  _mqtt = new Adafruit_MQTT_Client(_client, _host, _mqtt_port);
+  _http = new HttpClient(*_client, _host, _http_port);
+}
+
+AdafruitIO_MKR1010::~AdafruitIO_MKR1010() {
+  if (_client)
+    delete _client;
+  if (_mqtt)
+    delete _mqtt;
+}
+
+void AdafruitIO_MKR1010::_connect() {
+  if (strlen(_ssid) == 0) {
+    _status = AIO_SSID_INVALID;
+  } else {
+    // no shield? bail
+    if (WiFi.status() == WL_NO_SHIELD)
+      return;
+
+    _disconnect();
+
+    WiFi.begin(_ssid, _pass);
+    _status = AIO_NET_DISCONNECTED;
+  }
+}
+
+/**************************************************************************/
+/*!
+    @brief    Disconnect the wifi network.
+*/
+/**************************************************************************/
+void AdafruitIO_MKR1010::_disconnect() {
+  WiFi.disconnect();
+  delay(AIO_NET_DISCONNECT_WAIT);
+}
+
+aio_status_t AdafruitIO_MKR1010::networkStatus() {
+
+  switch (WiFi.status()) {
+  case WL_CONNECTED:
+    return AIO_NET_CONNECTED;
+  case WL_CONNECT_FAILED:
+    return AIO_NET_CONNECT_FAILED;
+  case WL_IDLE_STATUS:
+    return AIO_IDLE;
+  default:
+    return AIO_NET_DISCONNECTED;
+  }
+}
+
+const char *AdafruitIO_MKR1010::connectionType() { return "wifi"; }
+
+#endif // ARDUINO_ARCH_SAMD

--- a/src/wifi/AdafruitIO_MKR1010.cpp
+++ b/src/wifi/AdafruitIO_MKR1010.cpp
@@ -6,7 +6,7 @@
  * products from Adafruit!
  *
  * Copyright (c) 2015-2016 Adafruit Industries
- * Authors: Tony DiCola, Todd Treece, Morgan Winters
+ * Authors: Tony DiCola, Todd Treece
  * Licensed under the MIT license.
  *
  * All text above must be included in any redistribution.

--- a/src/wifi/AdafruitIO_MKR1010.h
+++ b/src/wifi/AdafruitIO_MKR1010.h
@@ -6,7 +6,7 @@
  * products from Adafruit!
  *
  * Copyright (c) 2015-2016 Adafruit Industries
- * Authors: Tony DiCola, Todd Treece, Morgan Winters
+ * Authors: Tony DiCola, Todd Treece
  * Licensed under the MIT license.
  *
  * All text above must be included in any redistribution.

--- a/src/wifi/AdafruitIO_MKR1010.h
+++ b/src/wifi/AdafruitIO_MKR1010.h
@@ -1,0 +1,50 @@
+/*!
+ * @file AdafruitIO_MKR1010.h
+ *
+ * Adafruit invests time and resources providing this open source code.
+ * Please support Adafruit and open source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) 2015-2016 Adafruit Industries
+ * Authors: Tony DiCola, Todd Treece, Morgan Winters
+ * Licensed under the MIT license.
+ *
+ * All text above must be included in any redistribution.
+ */
+
+#ifndef ADAFRUITIO_MKR1010_H
+#define ADAFRUITIO_MKR1010_H
+
+#if defined(ARDUINO_SAMD_MKR1010)
+
+#include "AdafruitIO.h"
+#include "Adafruit_MQTT.h"
+#include "Adafruit_MQTT_Client.h"
+#include "Arduino.h"
+#include "SPI.h"
+#include "WiFiNINA.h"
+#include "WiFiSSLClient.h"
+
+class AdafruitIO_MKR1010 : public AdafruitIO {
+
+public:
+  AdafruitIO_MKR1010(const char *user, const char *key, const char *ssid,
+                     const char *pass);
+  ~AdafruitIO_MKR1010();
+
+  aio_status_t networkStatus();
+  const char *connectionType();
+
+protected:
+  void _connect();
+  void _disconnect();
+
+  const char *_ssid;
+  const char *_pass;
+
+  WiFiSSLClient *_client;
+};
+
+#endif // ARDUINO_ARCH_SAMD
+
+#endif // ADAFRUITIO_MKR1010_H

--- a/src/wifi/AdafruitIO_WINC1500.h
+++ b/src/wifi/AdafruitIO_WINC1500.h
@@ -6,7 +6,7 @@
  * products from Adafruit!
  *
  * Copyright (c) 2015-2016 Adafruit Industries
- * Authors: Tony DiCola, Todd Treece, Morgan Winters
+ * Authors: Tony DiCola, Todd Treece
  * Licensed under the MIT license.
  *
  * All text above must be included in any redistribution.

--- a/src/wifi/AdafruitIO_WINC1500.h
+++ b/src/wifi/AdafruitIO_WINC1500.h
@@ -15,7 +15,7 @@
 #ifndef ADAFRUITIO_WINC1500_H
 #define ADAFRUITIO_WINC1500_H
 
-#if !defined(ARDUINO_SAMD_MKR1000) && defined(ARDUINO_ARCH_SAMD) &&            \
+#if !defined(ARDUINO_SAMD_MKR1000) && !defined(ARDUINO_SAMD_MKR1010) && defined(ARDUINO_ARCH_SAMD) &&            \
     !defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) && !defined(ADAFRUIT_PYPORTAL)
 
 #include "AdafruitIO.h"
@@ -130,7 +130,8 @@ protected:
       _status = AIO_SSID_INVALID;
     } else {
       _disconnect();
-      WiFi.setPins(_winc_cs, _winc_irq, _winc_rst, _winc_en);
+      // Comment out line below for MKR1010
+      //WiFi.setPins(_winc_cs, _winc_irq, _winc_rst, _winc_en); //
 
       // no shield? bail
       if (WiFi.status() == WL_NO_SHIELD) {

--- a/src/wifi/AdafruitIO_WINC1500.h
+++ b/src/wifi/AdafruitIO_WINC1500.h
@@ -6,7 +6,7 @@
  * products from Adafruit!
  *
  * Copyright (c) 2015-2016 Adafruit Industries
- * Authors: Tony DiCola, Todd Treece
+ * Authors: Tony DiCola, Todd Treece, Morgan Winters
  * Licensed under the MIT license.
  *
  * All text above must be included in any redistribution.
@@ -23,7 +23,8 @@
 #include "Adafruit_MQTT_Client.h"
 #include "Arduino.h"
 #include "SPI.h"
-#include "WiFi101.h"
+//#include "WiFi101.h" // USE THIS FOR WiFi101 boards such as the MKR1000
+#include "WiFiNINA.h  // USE THIS FOR WiFiNINA boards such as the MKR1010
 
 /**************************************************************************/
 /*!

--- a/src/wifi/AdafruitIO_WINC1500.h
+++ b/src/wifi/AdafruitIO_WINC1500.h
@@ -15,8 +15,9 @@
 #ifndef ADAFRUITIO_WINC1500_H
 #define ADAFRUITIO_WINC1500_H
 
-#if !defined(ARDUINO_SAMD_MKR1000) && !defined(ARDUINO_SAMD_MKR1010) && defined(ARDUINO_ARCH_SAMD) &&            \
-    !defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) && !defined(ADAFRUIT_PYPORTAL)
+#if !defined(ARDUINO_SAMD_MKR1000) && !defined(ARDUINO_SAMD_MKR1010) &&            \
+    defined(ARDUINO_ARCH_SAMD) && !defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) &&            \
+    !defined(ADAFRUIT_PYPORTAL)
 
 #include "AdafruitIO.h"
 #include "Adafruit_MQTT.h"


### PR DESCRIPTION
Added support to allow users to use the Arduino MKR1010 WiFi with Adafruit IO.

Added support into: src/AdafruitIO_WiFi.h - line 23 to 27 
Added new file:  src/wifi/AdafruitIO_MKR1010.cpp
Added new file:  src/wifi/AdafruitIO_MKR1010.h

Added support into: src/wifi/AdafruitIO_WINC1500.h
Added "#include "WiFiNINA.h" and option to still use "#include "WiFi101.h"" by commenting out one or the other.
Added  "// Comment out line below for MKR1010" and added // to line 133 WiFi.setPins(_winc_cs, _winc_irq, _winc_rst, _winc_en);  to allow the MKR1010/WiFiNINA to work.
