### PR TITLE
Remove SSL for ESP8266 Platform

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -26,10 +26,12 @@ jobs:
       run: bash ci/actions_install.sh
 
 
-    # manually install WiFi
+    # manually install WiFi and HTTPClient
     - name: extra libraries
       run: |
         git clone --quiet https://github.com/adafruit/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
+        rm -rf /home/runner/Arduino/libraries/ArduinoHttpClient
+        git clone --quiet https://github.com/brentru/ArduinoHttpClient.git /home/runner/Arduino/libraries/ArduinoHttpClient
 
     - name: test platforms
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         git clone --quiet https://github.com/adafruit/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
         rm -rf /home/runner/Arduino/libraries/ArduinoHttpClient
-        git clone --quiet https://github.com/brentru/ArduinoHttpClient.git /home/runner/Arduino/libraries/ArduinoHttpClient
+        git clone --quiet https://github.com/arduino-libraries/ArduinoHttpClient.git /home/runner/Arduino/libraries/ArduinoHttpClient
 
     - name: test platforms
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![AIOArduino](https://cdn-learn.adafruit.com/assets/assets/000/057/496/original/adafruit_io_AIOA.png?1531335660)
 
-This library provides a simple device independent interface for interacting with [Adafruit IO](https://io.adafruit.com) using Arduino. It allows you to switch between WiFi (ESP8266, ESP32, ESP32-S2, Airlift, WINC1500, & WICED), Cellular (32u4 FONA), and Ethernet (Ethernet FeatherWing).
+This library provides a simple device independent interface for interacting with [Adafruit IO](https://io.adafruit.com) using Arduino. It allows you to switch between WiFi (ESP8266, ESP32, ESP32-S2, ESP32-S3, ESP32-C3, Airlift, WINC1500, & WICED), Cellular (32u4 FONA), and Ethernet (Ethernet FeatherWing).
 
 ## Documentation
 

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library to access Adafruit IO using the Adafruit AirLift, ESP8
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit MQTT Library, ArduinoHttpClient, HTTPClient, Adafruit Unified Sensor, Adafruit NeoPixel, DHT sensor library, Ethernet, Adafruit Si7021 Library, Adafruit SGP30 Sensor, Adafruit BME280 Library, Adafruit LIS3DH, Adafruit VEML6070 Library, ESP32Servo
+depends=Adafruit MQTT Library, ArduinoHttpClient, Adafruit Unified Sensor, Adafruit NeoPixel, DHT sensor library, Ethernet, Adafruit Si7021 Library, Adafruit SGP30 Sensor, Adafruit BME280 Library, Adafruit LIS3DH, Adafruit VEML6070 Library, ESP32Servo

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library to access Adafruit IO using the Adafruit AirLift, ESP8
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit MQTT Library, ArduinoHttpClient, Adafruit Unified Sensor, Adafruit NeoPixel, DHT sensor library, Ethernet, Adafruit Si7021 Library, Adafruit SGP30 Sensor, Adafruit BME280 Library, Adafruit LIS3DH, Adafruit VEML6070 Library, ESP32Servo
+depends=Adafruit MQTT Library, ArduinoHttpClient, HTTPClient, Adafruit Unified Sensor, Adafruit NeoPixel, DHT sensor library, Ethernet, Adafruit Si7021 Library, Adafruit SGP30 Sensor, Adafruit BME280 Library, Adafruit LIS3DH, Adafruit VEML6070 Library, ESP32Servo

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit IO Arduino
-version=4.2.0
+version=4.2.1
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library to access Adafruit IO.

--- a/src/AdafruitIO.h
+++ b/src/AdafruitIO.h
@@ -24,7 +24,13 @@
 #include "AdafruitIO_Time.h"
 #include "Adafruit_MQTT.h"
 #include "Arduino.h"
+#if defined ARDUINO_ARCH_ESP32
+// use HTTP Client for ESP32
+#include "HTTPClient.h"
+#else
+// use generic HTTP client for Arduino
 #include "ArduinoHttpClient.h"
+#endif
 #include "util/AdafruitIO_Board.h"
 
 #ifndef ADAFRUIT_MQTT_VERSION_MAJOR

--- a/src/AdafruitIO.h
+++ b/src/AdafruitIO.h
@@ -148,7 +148,11 @@ protected:
                                       Adafruit IO, in milliseconds */
 
   Adafruit_MQTT *_mqtt; /*!< Reference to Adafruit_MQTT, _mqtt. */
-  HttpClient *_http;    /*!< Reference to HTTPClient, _http */
+ #if defined ARDUINO_ARCH_ESP32
+ HTTPClient *_http;    /*!< Reference to ESP32 HTTPClient, _http */
+ #else
+ HttpClient *_http;    /*!< Reference to HTTPClient, _http */
+ #endif
 
   char _version[10]; /*!< Adafruit IO Arduino library version */
 

--- a/src/AdafruitIO.h
+++ b/src/AdafruitIO.h
@@ -24,13 +24,7 @@
 #include "AdafruitIO_Time.h"
 #include "Adafruit_MQTT.h"
 #include "Arduino.h"
-#if defined ARDUINO_ARCH_ESP32
-// use HTTP Client for ESP32
-#include "HTTPClient.h"
-#else
-// use generic HTTP client for Arduino
 #include "ArduinoHttpClient.h"
-#endif
 #include "util/AdafruitIO_Board.h"
 
 #ifndef ADAFRUIT_MQTT_VERSION_MAJOR
@@ -148,11 +142,7 @@ protected:
                                       Adafruit IO, in milliseconds */
 
   Adafruit_MQTT *_mqtt; /*!< Reference to Adafruit_MQTT, _mqtt. */
- #if defined ARDUINO_ARCH_ESP32
- HTTPClient *_http;    /*!< Reference to ESP32 HTTPClient, _http */
- #else
- HttpClient *_http;    /*!< Reference to HTTPClient, _http */
- #endif
+  HttpClient *_http;    /*!< Reference to HTTPClient, _http */
 
   char _version[10]; /*!< Adafruit IO Arduino library version */
 

--- a/src/AdafruitIO_Data.cpp
+++ b/src/AdafruitIO_Data.cpp
@@ -873,6 +873,7 @@ char **parse_csv(const char *line) {
       continue;
     case '\0':
       fEnd = 1;
+      continue;
     case ',':
       *tptr = '\0';
       *bptr = strdup(tmp);

--- a/src/AdafruitIO_Definitions.h
+++ b/src/AdafruitIO_Definitions.h
@@ -16,9 +16,9 @@
 #ifndef ADAFRUITIO_DEFINITIONS_H_
 #define ADAFRUITIO_DEFINITIONS_H_
 
-#define ADAFRUITIO_VERSION_MAJOR 3 ///< Adafruit IO Arduino Major Semvar
-#define ADAFRUITIO_VERSION_MINOR 5 ///< Adafruit IO Arduino Minor Semvar
-#define ADAFRUITIO_VERSION_PATCH 0 ///< Adafruit IO Arduino Patch Semvar
+#define ADAFRUITIO_VERSION_MAJOR 4 ///< Adafruit IO Arduino Major Semvar
+#define ADAFRUITIO_VERSION_MINOR 2 ///< Adafruit IO Arduino Minor Semvar
+#define ADAFRUITIO_VERSION_PATCH 1 ///< Adafruit IO Arduino Patch Semvar
 
 // forward declaration
 class AdafruitIO_Data;

--- a/src/AdafruitIO_Definitions.h
+++ b/src/AdafruitIO_Definitions.h
@@ -125,14 +125,14 @@ public:
                                                                 ///< Fingerprint
 
 #define AIO_FEED_NAME_LENGTH                                                   \
-  258 ///< Maximum length of an Adafruit IO Feed    \
-                                  ///< Name; 128 + 1 + 128 for the group, a dot \
-                                  ///< , and actual feed name.
+  258 ///< Maximum length of an Adafruit IO Feed: Name; 128 + 1 + 128 for the
+      ///< group, a dot, and actual feed name.
+
 #define AIO_DATA_LENGTH                                                        \
   45 ///< Maximum length of data sent/recieved from Adafruit IO
 #define AIO_CSV_LENGTH                                                         \
-  AIO_FEED_NAME_LENGTH + 4 ///< Maximum comma-separated-value length from \
-                           ///< Adafruit IO
+  AIO_FEED_NAME_LENGTH +                                                       \
+      4 ///< Maximum comma-separated-value length from Adafruit IO
 
 /** aio_status_t offers 13 status states */
 typedef enum {

--- a/src/wifi/AdafruitIO_ESP8266.cpp
+++ b/src/wifi/AdafruitIO_ESP8266.cpp
@@ -21,6 +21,11 @@ AdafruitIO_ESP8266::AdafruitIO_ESP8266(const char *user, const char *key,
     : AdafruitIO(user, key) {
   _ssid = ssid;
   _pass = pass;
+  // Uncomment the following lines and remove the existing WiFiClient and MQTT
+  // client constructors to use Secure MQTT with ESP8266.
+  // _client = new WiFiClientSecure;
+  // _client->setFingerprint(AIO_SSL_FINGERPRINT);
+  // _mqtt = new Adafruit_MQTT_Client(_client, _host, _mqtt_port);
   _client = new WiFiClient;
   _mqtt = new Adafruit_MQTT_Client(_client, _host, 1883);
   _http = new HttpClient(*_client, _host, _http_port);

--- a/src/wifi/AdafruitIO_ESP8266.cpp
+++ b/src/wifi/AdafruitIO_ESP8266.cpp
@@ -21,9 +21,8 @@ AdafruitIO_ESP8266::AdafruitIO_ESP8266(const char *user, const char *key,
     : AdafruitIO(user, key) {
   _ssid = ssid;
   _pass = pass;
-  _client = new WiFiClientSecure;
-  _client->setFingerprint(AIO_SSL_FINGERPRINT);
-  _mqtt = new Adafruit_MQTT_Client(_client, _host, _mqtt_port);
+  _client = new WiFiClient;
+  _mqtt = new Adafruit_MQTT_Client(_client, _host, 1883);
   _http = new HttpClient(*_client, _host, _http_port);
 }
 

--- a/src/wifi/AdafruitIO_ESP8266.h
+++ b/src/wifi/AdafruitIO_ESP8266.h
@@ -22,6 +22,17 @@
 #include "Adafruit_MQTT_Client.h"
 #include "Arduino.h"
 #include "ESP8266WiFi.h"
+/* NOTE - Projects that require "Secure MQTT" (TLS/SSL) also require a new
+ * SSL certificate every year. If adding Secure MQTT to your ESP8266 project is
+ * important  - please switch to using the modern ESP32 (and related models)
+ * instead of the ESP8266 to avoid updating the SSL fingerprint every year.
+ *
+ * If you've read through this and still want to use "Secure MQTT" with your
+ * ESP8266 project, we've left the "WiFiClientSecure" lines commented out. To
+ * use them, uncomment the commented out lines within `AdafruitIO_ESP8266.h` and
+ * `AdafruitIO_ESP8266.cpp` and recompile the library.
+ */
+// #include "WiFiClientSecure.h"
 
 class AdafruitIO_ESP8266 : public AdafruitIO {
 
@@ -40,6 +51,9 @@ protected:
   const char *_ssid;
   const char *_pass;
   WiFiClient *_client;
+  // Uncomment the following line, and remove the line above, to use
+  // secure MQTT with ESP8266.
+  // WiFiClientSecure *_client;
 };
 
 #endif // ESP8266

--- a/src/wifi/AdafruitIO_ESP8266.h
+++ b/src/wifi/AdafruitIO_ESP8266.h
@@ -22,7 +22,6 @@
 #include "Adafruit_MQTT_Client.h"
 #include "Arduino.h"
 #include "ESP8266WiFi.h"
-#include "WiFiClientSecure.h"
 
 class AdafruitIO_ESP8266 : public AdafruitIO {
 
@@ -40,7 +39,7 @@ protected:
 
   const char *_ssid;
   const char *_pass;
-  WiFiClientSecure *_client;
+  WiFiClient *_client;
 };
 
 #endif // ESP8266


### PR DESCRIPTION
Projects that require "Secure MQTT" (TLS/SSL) on ESP8266 also require a new SSL certificate + SSL fingerprint every year. 

* Warning/Info text has been added to `src/wifi/AdafruitIO_ESP8266.h` advising users to upgrade to the ESP32 platform if using SSL/TLS with an Adafruit IO Arduino project.
  * For users who still want to experiment - existing lines have been commented out and instructions about compiling included.
* Fixed ESP32-BSP warnings
* Updated workflow file to perform manual installation of HTTPClient due to ESP32-BSP warnings
  * Related: https://github.com/arduino-libraries/ArduinoHttpClient/issues/138
* Bumped semver, updated boards supported via README


Tested on an Adafruit Feather ESP8266 Huzzah running the publish+subscribe example within this library.