### PR TITLE
Fix ESP8266 fallthrough patch causing memory error, add updated ssl cert

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit IO Arduino
-version=4.2.1
+version=4.2.2
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library to access Adafruit IO.

--- a/src/AdafruitIO_Data.cpp
+++ b/src/AdafruitIO_Data.cpp
@@ -873,7 +873,7 @@ char **parse_csv(const char *line) {
       continue;
     case '\0':
       fEnd = 1;
-      continue;
+      break;
     case ',':
       *tptr = '\0';
       *bptr = strdup(tmp);

--- a/src/AdafruitIO_Definitions.h
+++ b/src/AdafruitIO_Definitions.h
@@ -119,7 +119,7 @@ public:
 // echo | openssl s_client -connect io.adafruit.com:443 | openssl x509
 // -fingerprint -noout
 #define AIO_SSL_FINGERPRINT                                                    \
-  "59 3C 48 0A B1 8B 39 4E 0D 58 50 47 9A 13 55 60 CC A0 1D AF" ///< Latest
+  "18 C0 C2 3D BE DD 81 37 73 40 E7 E4 36 61 CB 0A DF 96 AD 25" ///< Latest
                                                                 ///< Adafruit IO
                                                                 ///< SSL
                                                                 ///< Fingerprint


### PR DESCRIPTION
Fixes io.run () exception issue discussed on https://forums.adafruit.com/viewtopic.php?t=193560 and https://forums.adafruit.com/viewtopic.php?t=193603

Also adds the latest SSL cert for ESP8266 (even though commented out) per topic:
https://forums.adafruit.com/viewtopic.php?t=193572

----

Test Hardware: Adafruit Feather Huzzah ESP8266
Sketches Tested:
- [xraymike](https://forums.adafruit.com/memberlist.php?mode=viewprofile&u=242909)
- [adafruitio_05_type_conversion](https://github.com/adafruit/Adafruit_IO_Arduino/blob/master/examples/adafruitio_05_type_conversion/adafruitio_05_type_conversion.ino)