### PR TITLE
Add WiFiManager compatibilty for ESP8266 & ESP32

### DIFF
--- a/examples/adafruitio_27_wifimanager/adafruit_27_wifimanager.ino
+++ b/examples/adafruitio_27_wifimanager/adafruit_27_wifimanager.ino
@@ -35,19 +35,16 @@ void handleMessage(AdafruitIO_Data *data)
 void setup()
 
 {
-  WiFi.mode(WIFI_STA);
-  Serial.begin(57600); // Initialize serial port for debugging.
+  Serial.begin(115200); // Initialize serial port for debugging.
   delay(500);
 
   // wifiManager.resetSettings();  //uncomment to reset the WiFi settings
 
-  wifiManager.setClass("invert");
-
-  wifiManager.setTimeout(120);
+  wifiManager.setClass("invert");          // enable "dark mode" for the config portal
   wifiManager.setConfigPortalTimeout(120); // auto close configportal after n seconds
   wifiManager.setAPClientCheck(true);      // avoid timeout if client connected to softap
 
-  if (!wifiManager.autoConnect("WiFi Setup"))
+  if (!wifiManager.autoConnect("WiFi Setup"))   // connect to wifi with existing setting or start config portal
   {
     Serial.println("failed to connect and hit timeout");
   }

--- a/examples/adafruitio_27_wifimanager/adafruit_27_wifimanager.ino
+++ b/examples/adafruitio_27_wifimanager/adafruit_27_wifimanager.ino
@@ -1,0 +1,83 @@
+/* Adafruit IO Example Using WiFiManager
+ *
+ * This is a simple Adafruit feed subscribe example that uses
+ * WiFiManager to handle setup of WiFi credentials and connecting
+ * to the network instead of defining the WiFI SSID and password
+ * explicitly in the code.
+ *
+ * To use this example, add your Adafruit IO Username and Key
+ * and setup a feed called "myfeed".  When you manually add data
+ * to the feed on io.adafruit.com, you'll see that data written to
+ * the serial output.
+ *
+ * Brad Black - 2022
+ *
+ */
+
+#include <WiFiManager.h>
+#include "AdafruitIO_WiFi.h"
+
+char IO_USERNAME[64] = "your username";
+char IO_KEY[64] = "your key";
+AdafruitIO_WiFi io(IO_USERNAME, IO_KEY);
+AdafruitIO_Feed *myfeed = io.feed("myfeed");
+
+WiFiManager wifiManager;
+
+void handleMessage(AdafruitIO_Data *data)
+{
+
+  Serial.print("received <- ");
+  Serial.println(data->toString());
+
+} // handleMessage
+
+void setup()
+
+{
+  WiFi.mode(WIFI_STA);
+  Serial.begin(57600); // Initialize serial port for debugging.
+  delay(500);
+
+  // wifiManager.resetSettings();  //uncomment to reset the WiFi settings
+
+  wifiManager.setClass("invert");
+
+  wifiManager.setTimeout(120);
+  wifiManager.setConfigPortalTimeout(120); // auto close configportal after n seconds
+  wifiManager.setAPClientCheck(true);      // avoid timeout if client connected to softap
+
+  if (!wifiManager.autoConnect("WiFi Setup"))
+  {
+    Serial.println("failed to connect and hit timeout");
+  }
+  else
+  {
+    // if you get here you have connected to the WiFi
+    Serial.println("Connected to WiFi.");
+
+    Serial.printf("Connecting to Adafruit IO with User: %s Key: %s.\n", IO_USERNAME, IO_KEY);
+    io.connect();
+
+    myfeed->onMessage(handleMessage);
+
+    myfeed->get();
+
+    // wait for a connection
+
+    while ((io.status() < AIO_CONNECTED))
+    {
+      Serial.print(".");
+      delay(500);
+    }
+    Serial.println("Connected to Adafruit IO.");
+  }
+
+} // setup()
+
+void loop()
+{
+
+  io.run();
+
+} // loop()

--- a/examples/adafruitio_27_wifimanager/adafruit_27_wifimanager.ino
+++ b/examples/adafruitio_27_wifimanager/adafruit_27_wifimanager.ino
@@ -17,9 +17,9 @@
 #include <WiFiManager.h>
 #include "AdafruitIO_WiFi.h"
 
-char IO_USERNAME[64] = "your username";
-char IO_KEY[64] = "your key";
-AdafruitIO_WiFi io(IO_USERNAME, IO_KEY);
+char IO_USERNAME[64] = "my username";
+char IO_KEY[64] = "my key";
+AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, "", "");
 AdafruitIO_Feed *myfeed = io.feed("myfeed");
 
 WiFiManager wifiManager;
@@ -44,7 +44,7 @@ void setup()
   wifiManager.setConfigPortalTimeout(120); // auto close configportal after n seconds
   wifiManager.setAPClientCheck(true);      // avoid timeout if client connected to softap
 
-  if (!wifiManager.autoConnect("WiFi Setup"))   // connect to wifi with existing setting or start config portal
+  if (!wifiManager.autoConnect("WiFi Setup"))   // connect to wifi with existing setting or start config
   {
     Serial.println("failed to connect and hit timeout");
   }

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library to access Adafruit IO using the Adafruit AirLift, ESP8
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit MQTT Library, ArduinoHttpClient, Adafruit Unified Sensor, Adafruit NeoPixel, DHT sensor library, Ethernet, Adafruit Si7021 Library, Adafruit SGP30 Sensor, Adafruit BME280 Library, Adafruit LIS3DH, Adafruit VEML6070 Library, ESP32Servo
+depends=Adafruit MQTT Library, ArduinoHttpClient, Adafruit Unified Sensor, Adafruit NeoPixel, DHT sensor library, Ethernet, Adafruit Si7021 Library, Adafruit SGP30 Sensor, Adafruit BME280 Library, Adafruit LIS3DH, Adafruit VEML6070 Library, ESP32Servo, WiFiManager

--- a/src/wifi/AdafruitIO_ESP32.cpp
+++ b/src/wifi/AdafruitIO_ESP32.cpp
@@ -25,7 +25,7 @@ AdafruitIO_ESP32::AdafruitIO_ESP32(const char *user, const char *key,
   _http = new HttpClient(*_client, _host, _http_port);
 }
 
-AdafruitIO_ESP8266::AdafruitIO_ESP8266(const char *user, const char *key)
+AdafruitIO_ESP32::AdafruitIO_ESP32(const char *user, const char *key)
     : AdafruitIO(user, key) {
 
   _ssid = NULL;

--- a/src/wifi/AdafruitIO_ESP32.cpp
+++ b/src/wifi/AdafruitIO_ESP32.cpp
@@ -54,8 +54,9 @@ if (_ssid != NULL) {
     delay(100);
     _status = AIO_NET_DISCONNECTED;
   }
-  _client->setCACert(_aio_root_ca);
  }
+  _client->setCACert(_aio_root_ca);
+ 
 }
 
 /**************************************************************************/

--- a/src/wifi/AdafruitIO_ESP32.cpp
+++ b/src/wifi/AdafruitIO_ESP32.cpp
@@ -25,6 +25,17 @@ AdafruitIO_ESP32::AdafruitIO_ESP32(const char *user, const char *key,
   _http = new HttpClient(*_client, _host, _http_port);
 }
 
+AdafruitIO_ESP8266::AdafruitIO_ESP8266(const char *user, const char *key)
+    : AdafruitIO(user, key) {
+
+  _ssid = NULL;
+  _pass = NULL;
+  _client = new WiFiClientSecure;
+  _mqtt = new Adafruit_MQTT_Client(_client, _host, _mqtt_port);
+  _http = new HttpClient(*_client, _host, _http_port);
+}
+
+
 AdafruitIO_ESP32::~AdafruitIO_ESP32() {
   if (_client)
     delete _client;
@@ -33,6 +44,7 @@ AdafruitIO_ESP32::~AdafruitIO_ESP32() {
 }
 
 void AdafruitIO_ESP32::_connect() {
+if (_ssid != NULL) {
   if (strlen(_ssid) == 0) {
     _status = AIO_SSID_INVALID;
   } else {
@@ -43,6 +55,7 @@ void AdafruitIO_ESP32::_connect() {
     _status = AIO_NET_DISCONNECTED;
   }
   _client->setCACert(_aio_root_ca);
+ }
 }
 
 /**************************************************************************/

--- a/src/wifi/AdafruitIO_ESP32.h
+++ b/src/wifi/AdafruitIO_ESP32.h
@@ -29,6 +29,8 @@ class AdafruitIO_ESP32 : public AdafruitIO {
 public:
   AdafruitIO_ESP32(const char *user, const char *key, const char *ssid,
                    const char *pass);
+  AdafruitIO_ESP8266(const char *user, const char *key);
+
   ~AdafruitIO_ESP32();
 
   aio_status_t networkStatus();

--- a/src/wifi/AdafruitIO_ESP32.h
+++ b/src/wifi/AdafruitIO_ESP32.h
@@ -29,7 +29,7 @@ class AdafruitIO_ESP32 : public AdafruitIO {
 public:
   AdafruitIO_ESP32(const char *user, const char *key, const char *ssid,
                    const char *pass);
-  AdafruitIO_ESP8266(const char *user, const char *key);
+  AdafruitIO_ESP32(const char *user, const char *key);
 
   ~AdafruitIO_ESP32();
 

--- a/src/wifi/AdafruitIO_ESP8266.cpp
+++ b/src/wifi/AdafruitIO_ESP8266.cpp
@@ -31,6 +31,21 @@ AdafruitIO_ESP8266::AdafruitIO_ESP8266(const char *user, const char *key,
   _http = new HttpClient(*_client, _host, _http_port);
 }
 
+AdafruitIO_ESP8266::AdafruitIO_ESP8266(const char *user, const char *key)
+    : AdafruitIO(user, key) {
+
+ _ssid = NULL;
+ _pass = NULL;
+  // Uncomment the following lines and remove the existing WiFiClient and MQTT
+  // client constructors to use Secure MQTT with ESP8266.
+  // _client = new WiFiClientSecure;
+  // _client->setFingerprint(AIO_SSL_FINGERPRINT);
+  // _mqtt = new Adafruit_MQTT_Client(_client, _host, _mqtt_port);
+  _client = new WiFiClient;
+  _mqtt = new Adafruit_MQTT_Client(_client, _host, 1883);
+  _http = new HttpClient(*_client, _host, _http_port);
+}
+
 AdafruitIO_ESP8266::~AdafruitIO_ESP8266() {
   if (_client)
     delete _client;
@@ -39,6 +54,7 @@ AdafruitIO_ESP8266::~AdafruitIO_ESP8266() {
 }
 
 void AdafruitIO_ESP8266::_connect() {
+if (_ssid != NULL) {
   if (strlen(_ssid) == 0) {
     _status = AIO_SSID_INVALID;
   } else {
@@ -48,6 +64,7 @@ void AdafruitIO_ESP8266::_connect() {
     delay(100);
     _status = AIO_NET_DISCONNECTED;
   }
+}
 }
 
 /**************************************************************************/

--- a/src/wifi/AdafruitIO_ESP8266.h
+++ b/src/wifi/AdafruitIO_ESP8266.h
@@ -39,6 +39,8 @@ class AdafruitIO_ESP8266 : public AdafruitIO {
 public:
   AdafruitIO_ESP8266(const char *user, const char *key, const char *ssid,
                      const char *pass);
+  AdafruitIO_ESP8266(const char *user, const char *key);
+
   ~AdafruitIO_ESP8266();
 
   aio_status_t networkStatus();


### PR DESCRIPTION
Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts of the code were modified.**  This will help us understand any risks of integrating the code.

Files changed..
src/wifi/AdafruitIO_ESP8266.h
src/wifi/AdafruitIO_ESP8266.cpp
src/wifi/AdafruitIO_ESP32.h
src/wifi/AdafruitIO_ESP32.cpp

Files added...
examples/adafruitio_27_wifimanager/adafruitio_27_wifimanager.ino

Overloaded the wifi functions with an additional method that only requires the AIO_USERNAME and AIO_KEY parameters.  The SSID and Password are not required as WiFiManager will be used to connect to wifi.  The connect code was changed to detect a NULL SSID and bypass the connect code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

Changes only apply to ESP8266 and ESP32 platforms which are supported by WiFiManager.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

I tested on both ESP8266 and ESP32 boards with a modified "subscribe" example sketch and the provided wifimanager example sketch.  The subscribe example used was: https://github.com/adafruit/Adafruit_IO_Arduino/tree/master/examples/adafruitio_01_subscribe but I modified this line as it was not working with the published library without this change...
 
  while io.mqqtStatus() < AIO_CONNECTED) {

was changed to..

   while(io.status() < AIO_CONNECTED) {

These tests exercised the existing 4 parameter invocation...

AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);

and the newly added 2 parameter method...

AdafruitIO_WiFi io(IO_USERNAME, IO_KEY);

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request.  There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

