### PR TITLE
Revert "Fix connectErrorString return type for ESP-32 BSP 2.0.8"

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit IO Arduino
-version=4.2.4
+version=4.2.3
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library to access Adafruit IO.

--- a/src/AdafruitIO.cpp
+++ b/src/AdafruitIO.cpp
@@ -243,18 +243,6 @@ AdafruitIO_Dashboard *AdafruitIO::dashboard(const char *name) {
   return new AdafruitIO_Dashboard(this, name);
 }
 
-// due to breaking change within Arduino ESP32 BSP v2.0.8
-// see: https://github.com/espressif/arduino-esp32/pull/7941
-#ifdef ARDUINO_ARCH_ESP32
-/**************************************************************************/
-/*!
-    @brief    Provide status explanation strings.
-    @return   A pointer to the status string literal, _status. _status is
-              the AIO status value
-*/
-/**************************************************************************/
-const char *AdafruitIO::statusText() {
-#else
 /**************************************************************************/
 /*!
     @brief    Provide status explanation strings.
@@ -263,7 +251,6 @@ const char *AdafruitIO::statusText() {
 */
 /**************************************************************************/
 const __FlashStringHelper *AdafruitIO::statusText() {
-#endif
   switch (_status) {
 
   // CONNECTING

--- a/src/AdafruitIO.h
+++ b/src/AdafruitIO.h
@@ -87,13 +87,7 @@ public:
   AdafruitIO_Dashboard *dashboard(const char *name);
   AdafruitIO_Time *time(aio_time_format_t format);
 
-// due to breaking change within Arduino ESP32 BSP v2.0.8
-// see: https://github.com/espressif/arduino-esp32/pull/7941
-#ifdef ARDUINO_ARCH_ESP32
-  const char *statusText();
-#else
   const __FlashStringHelper *statusText();
-#endif
 
   aio_status_t status();
   /********************************************************************/


### PR DESCRIPTION
Reverts adafruit/Adafruit_IO_Arduino#165

**Why?**
The "Arduino Release v2.0.9 based on ESP-IDF v4.4.4" PR https://github.com/espressif/arduino-esp32/pull/8147 is to "revert to the previous definition of FPSTR and F macros". In #165, we patched this breaking change. This pull request is reverting the patch.