### PR TITLE
unsecured network support for WINC1500

### DIFF
--- a/src/wifi/AdafruitIO_WINC1500.h
+++ b/src/wifi/AdafruitIO_WINC1500.h
@@ -137,7 +137,10 @@ protected:
         return;
       }
 
-      WiFi.begin(_ssid, _pass);
+      if (_pass && strlen(_pass) > 0)
+        WiFi.begin(_ssid, _pass);
+      else
+        WiFi.begin(_ssid);
       _status = AIO_NET_DISCONNECTED;
     }
   }


### PR DESCRIPTION
tested on Feather M0 WiFi.
to connect to an unsecured network (no password), simply pass in an empty string for `WIFI_PASS` in the call
`AdafruitIO_WiFi io(IO_USERNAME, IO_KEY, WIFI_SSID, WIFI_PASS);`

in the example code, can just change `#define WIFI_PASS ""`