### PR TITLE
docs(ssl): Update TLS/SSL certificate fingerprint instructions

### DIFF
--- a/src/AdafruitIO_Definitions.h
+++ b/src/AdafruitIO_Definitions.h
@@ -115,12 +115,12 @@ public:
 #define AIO_ERROR_TOPIC "/errors"      ///< Adafruit IO Error MQTT Topic
 #define AIO_THROTTLE_TOPIC "/throttle" ///< Adafruit IO Throttle MQTT Topic
 
-// io.adafruit.com TLS/SSL certificate changes every 6months, and pinning
-// certificates is no longer recommended. Migrate to a larger MCU like esp32
-// which can accomodate root certificates and verify chains of trust. For
-// older devices like esp8266 you can generate the latest fingerprint with:
-// echo | openssl s_client -connect io.adafruit.com:443 | openssl x509
-// -fingerprint -noout
+/* NB: io.adafruit.com TLS/SSL certificate changes every 6months, and pinning
+certificates is no longer recommended. Migrate to a larger MCU like ESP32
+which can accomodate root certificates and verify chains of trust.  */
+/* For older devices like ESP8266 you can generate the latest fingerprint with:
+echo | openssl s_client -connect io.adafruit.com:443 | openssl x509 -fingerprint -noout
+*/
 #define AIO_SSL_FINGERPRINT                                                    \
   "47 D2 CB 14 DF 38 97 59 C6 65 1A 1F 3E 00 1E 53 CC A5 17 E0" ///< Latest
                                                                 ///< Adafruit IO

--- a/src/AdafruitIO_Definitions.h
+++ b/src/AdafruitIO_Definitions.h
@@ -115,7 +115,10 @@ public:
 #define AIO_ERROR_TOPIC "/errors"      ///< Adafruit IO Error MQTT Topic
 #define AIO_THROTTLE_TOPIC "/throttle" ///< Adafruit IO Throttle MQTT Topic
 
-// latest fingerprint can be generated with
+// io.adafruit.com TLS/SSL certificate changes every 6months, and pinning
+// certificates is no longer recommended. Migrate to a larger MCU like esp32
+// which can accomodate root certificates and verify chains of trust. For
+// older devices like esp8266 you can generate the latest fingerprint with:
 // echo | openssl s_client -connect io.adafruit.com:443 | openssl x509
 // -fingerprint -noout
 #define AIO_SSL_FINGERPRINT                                                    \

--- a/src/AdafruitIO_Definitions.h
+++ b/src/AdafruitIO_Definitions.h
@@ -119,7 +119,8 @@ public:
 certificates is no longer recommended. Migrate to a larger MCU like ESP32
 which can accomodate root certificates and verify chains of trust.  */
 /* For older devices like ESP8266 you can generate the latest fingerprint with:
-echo | openssl s_client -connect io.adafruit.com:443 | openssl x509 -fingerprint -noout
+echo | openssl s_client -connect io.adafruit.com:443 | openssl x509 -fingerprint
+-noout
 */
 #define AIO_SSL_FINGERPRINT                                                    \
   "47 D2 CB 14 DF 38 97 59 C6 65 1A 1F 3E 00 1E 53 CC A5 17 E0" ///< Latest

--- a/src/AdafruitIO_Definitions.h
+++ b/src/AdafruitIO_Definitions.h
@@ -115,7 +115,7 @@ public:
 #define AIO_ERROR_TOPIC "/errors"      ///< Adafruit IO Error MQTT Topic
 #define AIO_THROTTLE_TOPIC "/throttle" ///< Adafruit IO Throttle MQTT Topic
 
-/* NB: io.adafruit.com TLS/SSL certificate changes every 6months, and pinning
+/* NOTE: io.adafruit.com TLS/SSL certificate changes every 6months, and pinning
 certificates is no longer recommended. Migrate to a larger MCU like ESP32
 which can accomodate root certificates and verify chains of trust.  */
 /* For older devices like ESP8266 you can generate the latest fingerprint with:

--- a/src/wifi/AdafruitIO_ESP8266.h
+++ b/src/wifi/AdafruitIO_ESP8266.h
@@ -25,12 +25,13 @@
 /* NOTE - Projects that require "Secure MQTT" (TLS/SSL) also require a new
  * SSL certificate every year. If adding Secure MQTT to your ESP8266 project is
  * important  - please switch to using the modern ESP32 (and related models)
- * instead of the ESP8266 to avoid updating the SSL fingerprint every year.
+ * instead of the ESP8266 to avoid updating the SSL fingerprint every 6months.
  *
  * If you've read through this and still want to use "Secure MQTT" with your
  * ESP8266 project, we've left the "WiFiClientSecure" lines commented out. To
  * use them, uncomment the commented out lines within `AdafruitIO_ESP8266.h` and
- * `AdafruitIO_ESP8266.cpp` and recompile the library.
+ * `AdafruitIO_ESP8266.cpp`, update fingerprint in `AdafruitIO_Definitions.h`,
+ *  and then recompile the library.
  */
 // #include "WiFiClientSecure.h"
 

--- a/src/wifi/AdafruitIO_ESP8266.h
+++ b/src/wifi/AdafruitIO_ESP8266.h
@@ -25,7 +25,7 @@
 /* NOTE - Projects that require "Secure MQTT" (TLS/SSL) also require a new
  * SSL certificate every year. If adding Secure MQTT to your ESP8266 project is
  * important  - please switch to using the modern ESP32 (and related models)
- * instead of the ESP8266 to avoid updating the SSL fingerprint every 6months.
+ * instead of the ESP8266 to avoid updating the SSL fingerprint every 6 months.
  *
  * If you've read through this and still want to use "Secure MQTT" with your
  * ESP8266 project, we've left the "WiFiClientSecure" lines commented out. To


### PR DESCRIPTION
Certificates for IO.adafruit.com are changing to a 6month validity, and it's felt that fingerprinting should no longer be recommended, but instructions updated as a large number of esp8266 users still exist on the IO platform.

Relates to:
https://3.basecamp.com/3732686/buckets/17625714/todos/9458087406