### PR TITLE
Fix _parseCSV() array index bug: lon and ele always returned lat value

### DIFF
--- a/src/AdafruitIO_Data.cpp
+++ b/src/AdafruitIO_Data.cpp
@@ -910,5 +910,4 @@ bool AdafruitIO_Data::_parseCSV() {
   } else {
     return false;
   }
-
 }

--- a/src/AdafruitIO_Data.cpp
+++ b/src/AdafruitIO_Data.cpp
@@ -890,12 +890,12 @@ bool AdafruitIO_Data::_parseCSV() {
     }
 
     if (field_count > 0) {
-      _lon = atof(fields[1]);
+      _lon = atof(fields[2]);
       field_count--;
     }
 
     if (field_count > 0) {
-      _ele = atof(fields[1]);
+      _ele = atof(fields[3]);
       field_count--;
     }
 
@@ -911,5 +911,4 @@ bool AdafruitIO_Data::_parseCSV() {
     return false;
   }
 
-  return true;
 }


### PR DESCRIPTION
Bug found and reported by gadgeteer on the [forums](https://forums.adafruit.com/viewtopic.php?t=223401).

In `_parseCSV()`, all three location fields hardcode `fields[1]`, so `lon` and `ele` always return the latitude value.

**Before (buggy):**
```cpp
_lat = atof(fields[1]);
_lon = atof(fields[1]);  // wrong — always returns lat
_ele = atof(fields[1]);  // wrong — always returns lat
```

**After (fixed):**
```cpp
_lat = atof(fields[1]);
_lon = atof(fields[2]);
_ele = atof(fields[3]);
```

Also removes the unreachable `return true;` at the end of the function.