### PR TITLE
Fix parse_csv() dropping the final CSV field

### DIFF
--- a/src/AdafruitIO_Data.cpp
+++ b/src/AdafruitIO_Data.cpp
@@ -823,6 +823,21 @@ char **parse_csv(const char *line) {
       fQuote = 1;
       continue;
     case '\0':
+      // Emit the final field. Previously this was dropped on the floor
+      // because the null terminator only set fEnd and broke the loop,
+      // so parse_csv() returned one fewer field than count_fields()
+      // reported. Callers reading fields[n-1] would then dereference NULL.
+      *tptr = '\0';
+      *bptr = strdup(tmp);
+      if (!*bptr) {
+        for (bptr--; bptr >= buf; bptr--) {
+          free(*bptr);
+        }
+        free(buf);
+        free(tmp);
+        return NULL;
+      }
+      bptr++;
       fEnd = 1;
       break;
     case ',':


### PR DESCRIPTION
## Summary

`parse_csv()` in `src/AdafruitIO_Data.cpp` silently drops the final field of every CSV it parses — for an N-field input it only populates slots `0..N-2`, leaving `NULL` at `N-1`.

## Root cause

The `'\0'` case in the parse loop breaks out without emitting the field accumulated since the last comma, unlike the `','` case which correctly `strdup`s each field.

## Fix

Emit the final field from inside the `'\0'` case before setting `fEnd`, using the same `strdup` + cleanup path as the `','` case.

## Relationship to #180

#180's index fix in `_parseCSV()` is correct but depends on this PR — without it, correcting the indices causes `atof(NULL)` → crash on every incoming location message. Suggest landing this first, then #180.

## Verification

Tested on Feather ESP32 V2 with both fixes applied:
```
=== parse_csv verification ===
lat: 10.111111
lon: 20.222222
ele: 30.333333
```

## Test plan
- [x] Unit-style sketch on Feather ESP32 V2: all four fields parsed correctly, no crash.
- [ ] - [ ] Maintainer sanity-check on another platform if desired.
🤖 Generated with [Claude Code](https://claude.com/claude-code)