### PR TITLE
Fix _parseCSV() array index bug: combined PR #180 and PR #181

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit IO Arduino
-version=4.3.4
+version=4.4.0
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library to access Adafruit IO.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit IO Arduino
-version=4.4.0
+version=4.3.5
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library to access Adafruit IO.

--- a/src/AdafruitIO_Data.cpp
+++ b/src/AdafruitIO_Data.cpp
@@ -823,6 +823,21 @@ char **parse_csv(const char *line) {
       fQuote = 1;
       continue;
     case '\0':
+      // Emit the final field. Previously this was dropped on the floor
+      // because the null terminator only set fEnd and broke the loop,
+      // so parse_csv() returned one fewer field than count_fields()
+      // reported. Callers reading fields[n-1] would then dereference NULL.
+      *tptr = '\0';
+      *bptr = strdup(tmp);
+      if (!*bptr) {
+        for (bptr--; bptr >= buf; bptr--) {
+          free(*bptr);
+        }
+        free(buf);
+        free(tmp);
+        return NULL;
+      }
+      bptr++;
       fEnd = 1;
       break;
     case ',':

--- a/src/AdafruitIO_Data.cpp
+++ b/src/AdafruitIO_Data.cpp
@@ -905,12 +905,12 @@ bool AdafruitIO_Data::_parseCSV() {
     }
 
     if (field_count > 0) {
-      _lon = atof(fields[1]);
+      _lon = atof(fields[2]);
       field_count--;
     }
 
     if (field_count > 0) {
-      _ele = atof(fields[1]);
+      _ele = atof(fields[3]);
       field_count--;
     }
 
@@ -926,5 +926,4 @@ bool AdafruitIO_Data::_parseCSV() {
     return false;
   }
 
-  return true;
 }

--- a/src/AdafruitIO_Data.cpp
+++ b/src/AdafruitIO_Data.cpp
@@ -925,5 +925,4 @@ bool AdafruitIO_Data::_parseCSV() {
   } else {
     return false;
   }
-
 }


### PR DESCRIPTION
Two bugs in the location CSV parsing that mask each other and together cause a crash on every received location message.

**#181** — `parse_csv()` silently dropped the last field of every CSV string, leaving `NULL` in the final slot instead of the elevation value.

**#180** — `_parseCSV()` read `fields[1]` three times instead of `fields[1]`, `fields[2]`, `fields[3]`, so `lon` and `ele` always returned the `lat` value.

Tested and verified on Adafruit Feather ESP32 V2, QT Py ESP32-S3, and Feather ESP8266.