### PR TITLE
Update - Remove ESP8266 SSL Fingerprint Comments

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit IO Arduino
-version=4.3.6
+version=4.3.7
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library to access Adafruit IO.

--- a/src/wifi/AdafruitIO_ESP8266.cpp
+++ b/src/wifi/AdafruitIO_ESP8266.cpp
@@ -21,11 +21,6 @@ AdafruitIO_ESP8266::AdafruitIO_ESP8266(const char *user, const char *key,
     : AdafruitIO(user, key) {
   _ssid = ssid;
   _pass = pass;
-  // Uncomment the following lines and remove the existing WiFiClient and MQTT
-  // client constructors to use Secure MQTT with ESP8266.
-  // _client = new WiFiClientSecure;
-  // _client->setFingerprint(AIO_SSL_FINGERPRINT);
-  // _mqtt = new Adafruit_MQTT_Client(_client, _host, _mqtt_port);
   _client = new WiFiClient;
   _mqtt = new Adafruit_MQTT_Client(_client, _host, 1883);
   _http = new HttpClient(*_client, _host, _http_port);

--- a/src/wifi/AdafruitIO_ESP8266.h
+++ b/src/wifi/AdafruitIO_ESP8266.h
@@ -22,18 +22,14 @@
 #include "Adafruit_MQTT_Client.h"
 #include "Arduino.h"
 #include "ESP8266WiFi.h"
-/* NOTE - Projects that require "Secure MQTT" (TLS/SSL) also require a new
- * SSL certificate every year. If adding Secure MQTT to your ESP8266 project is
- * important  - please switch to using the modern ESP32 (and related models)
- * instead of the ESP8266 to avoid updating the SSL fingerprint every 6 months.
- *
- * If you've read through this and still want to use "Secure MQTT" with your
- * ESP8266 project, we've left the "WiFiClientSecure" lines commented out. To
- * use them, uncomment the commented out lines within `AdafruitIO_ESP8266.h` and
- * `AdafruitIO_ESP8266.cpp`, update fingerprint in `AdafruitIO_Definitions.h`,
- *  and then recompile the library.
+
+/* NOTE - As of 07/21/26, this library no longer supports "Secure MQTT"
+ * (TLS/SSL) on the ESP8266 due to new automatic certificate updates that
+ * require a new certificate every 199 days (or less) -
+ * https://forums.adafruit.com/viewtopic.php?t=224362 If you would like a secure
+ * Adafruit IO Arduino project, please switch to using the modern ESP32 (and
+ * related models) instead of the ESP8266.
  */
-// #include "WiFiClientSecure.h"
 
 class AdafruitIO_ESP8266 : public AdafruitIO {
 
@@ -52,9 +48,6 @@ protected:
   const char *_ssid;
   const char *_pass;
   WiFiClient *_client;
-  // Uncomment the following line, and remove the line above, to use
-  // secure MQTT with ESP8266.
-  // WiFiClientSecure *_client;
 };
 
 #endif // ESP8266


### PR DESCRIPTION
Removing comments relating to SSL fingerprinting for ESP8266 MCUs due to [this notice](https://forums.adafruit.com/viewtopic.php?t=224362&__cf_chl_f_tk=E79n1_ySHvBOan6VzKtCldoDCPeIdtgJ76FTJIInZZM-1783016389-1.0.1.1-2ko4X7AaUGvatPBNPsIIctqA5fmx_XCwjMk7iHBy3ow).